### PR TITLE
[인터뷰] 면접 주제 호출 로직 고도화 및 질문 개수 선택 페이지 추가

### DIFF
--- a/lib/app/di/modules/interview_di.dart
+++ b/lib/app/di/modules/interview_di.dart
@@ -5,6 +5,7 @@ import 'package:techtalk/features/interview/data/remote/interview_remote_data_so
 import 'package:techtalk/features/interview/interview.dart';
 import 'package:techtalk/features/interview/repositories/interview_repository_impl.dart';
 import 'package:techtalk/features/interview/usecases/get_review_note_question_list_use_case.dart';
+import 'package:techtalk/features/user/user.dart';
 
 final class InterviewDependencyInjection extends FeatureDependencyInjection {
   @override
@@ -33,7 +34,8 @@ final class InterviewDependencyInjection extends FeatureDependencyInjection {
     GetIt.I
       ..registerFactory<GetInterviewTopicListUseCase>(
         () => GetInterviewTopicListUseCase(
-          interviewRepository,
+          interviewRepository: interviewRepository,
+          userRepository: userRepository,
         ),
       )
       ..registerFactory<GetReviewNoteQuestionListUseCase>(

--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -8,6 +8,8 @@ import 'package:techtalk/features/shared/enums/interviewer_avatar.dart';
 import 'package:techtalk/presentation/pages/interview/chat/chat_page.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/chat_page_route_argument_provider.dart';
 import 'package:techtalk/presentation/pages/interview/chat_list/chat_list_page.dart';
+import 'package:techtalk/presentation/pages/interview/questino_count_select/provider/question_count_select_page_route_arg_provider.dart';
+import 'package:techtalk/presentation/pages/interview/questino_count_select/question_count_select_page.dart';
 import 'package:techtalk/presentation/pages/interview/topic_select/interview_topic_select_page.dart';
 import 'package:techtalk/presentation/pages/main/main_page.dart';
 import 'package:techtalk/presentation/pages/sign_in/sign_in_page.dart';
@@ -17,6 +19,7 @@ import 'package:techtalk/presentation/pages/study/learning/providers/selected_st
 import 'package:techtalk/presentation/pages/study/learning/study_learning_page.dart';
 
 part 'route_argument.dart';
+
 part 'router.g.dart';
 
 final rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -90,18 +93,27 @@ class SignUpRoute extends GoRouteData {
     TypedGoRoute<HomeTopicSelectRoute>(
       path: HomeTopicSelectRoute.name,
       name: HomeTopicSelectRoute.name,
+      routes: [
+        TypedGoRoute<QuestionCountSelectPageRoute>(
+          path: QuestionCountSelectPageRoute.name,
+          name: QuestionCountSelectPageRoute.name,
+        ),
+      ],
     ),
     TypedGoRoute<StudyRoute>(
       path: StudyRoute.name,
       name: StudyRoute.name,
     ),
     TypedGoRoute<ChatListPageRoute>(
-        path: ChatListPageRoute.name,
-        name: ChatListPageRoute.name,
-        routes: [
-          TypedGoRoute<ChatPageRoute>(
-              path: ChatPageRoute.name, name: ChatPageRoute.name)
-        ]),
+      path: ChatListPageRoute.name,
+      name: ChatListPageRoute.name,
+      routes: [
+        TypedGoRoute<ChatPageRoute>(
+          path: ChatPageRoute.name,
+          name: ChatPageRoute.name,
+        )
+      ],
+    ),
   ],
 )
 class MainRoute extends GoRouteData {
@@ -112,6 +124,20 @@ class MainRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return MainPage();
+  }
+}
+
+class StudyRoute extends GoRouteData {
+  const StudyRoute(this.topicName);
+
+  final String topicName;
+  static const String name = 'study';
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    SelectedStudyTopic.topicName = topicName;
+
+    return const StudyLearningPage();
   }
 }
 
@@ -126,17 +152,21 @@ class HomeTopicSelectRoute extends GoRouteData {
   }
 }
 
-class StudyRoute extends GoRouteData {
-  const StudyRoute(this.topicName);
+class QuestionCountSelectPageRoute extends GoRouteData {
+  const QuestionCountSelectPageRoute({required this.selectedTopic});
 
-  final String topicName;
-  static const String name = 'study';
+  final InterviewTopic selectedTopic;
+
+  static const String name = 'question-count-select';
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    SelectedStudyTopic.topicName = topicName;
-
-    return StudyLearningPage();
+    return ProviderScope(
+      overrides: [
+        questionCountSelectRouteArgProvider.overrideWithValue(selectedTopic),
+      ],
+      child: QuestionCountSelectPage(),
+    );
   }
 }
 

--- a/lib/app/router/router.g.dart
+++ b/lib/app/router/router.g.dart
@@ -91,6 +91,13 @@ RouteBase get $mainRoute => GoRouteData.$route(
           path: 'topic-select',
           name: 'topic-select',
           factory: $HomeTopicSelectRouteExtension._fromState,
+          routes: [
+            GoRouteData.$route(
+              path: 'question-count-select',
+              name: 'question-count-select',
+              factory: $QuestionCountSelectPageRouteExtension._fromState,
+            ),
+          ],
         ),
         GoRouteData.$route(
           path: 'study',
@@ -146,6 +153,42 @@ extension $HomeTopicSelectRouteExtension on HomeTopicSelectRoute {
 
   void replace(BuildContext context) => context.replace(location);
 }
+
+extension $QuestionCountSelectPageRouteExtension
+    on QuestionCountSelectPageRoute {
+  static QuestionCountSelectPageRoute _fromState(GoRouterState state) =>
+      QuestionCountSelectPageRoute(
+        selectedTopic: _$InterviewTopicEnumMap
+            ._$fromName(state.uri.queryParameters['selected-topic']!),
+      );
+
+  String get location => GoRouteData.$location(
+        '/topic-select/question-count-select',
+        queryParams: {
+          'selected-topic': _$InterviewTopicEnumMap[selectedTopic],
+        },
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+const _$InterviewTopicEnumMap = {
+  InterviewTopic.java: 'java',
+  InterviewTopic.spring: 'spring',
+  InterviewTopic.react: 'react',
+  InterviewTopic.swift: 'swift',
+  InterviewTopic.flutter: 'flutter',
+  InterviewTopic.android: 'android',
+  InterviewTopic.dataStructure: 'data-structure',
+  InterviewTopic.operatingSystem: 'operating-system',
+};
 
 extension $StudyRouteExtension on StudyRoute {
   static StudyRoute _fromState(GoRouterState state) => StudyRoute(
@@ -225,17 +268,6 @@ const _$InterviewProgressStateEnumMap = {
   InterviewProgressState.initial: 'initial',
   InterviewProgressState.ongoing: 'ongoing',
   InterviewProgressState.completed: 'completed',
-};
-
-const _$InterviewTopicEnumMap = {
-  InterviewTopic.java: 'java',
-  InterviewTopic.spring: 'spring',
-  InterviewTopic.react: 'react',
-  InterviewTopic.swift: 'swift',
-  InterviewTopic.flutter: 'flutter',
-  InterviewTopic.android: 'android',
-  InterviewTopic.dataStructure: 'data-structure',
-  InterviewTopic.operatingSystem: 'operating-system',
 };
 
 const _$InterviewerAvatarEnumMap = {

--- a/lib/features/chat/data/remote/chat_remote_data_source_impl.dart
+++ b/lib/features/chat/data/remote/chat_remote_data_source_impl.dart
@@ -36,8 +36,6 @@ final class ChatRemoteDataSourceImpl implements ChatRemoteDataSource {
         .collection(FirestoreCollection.chats.name);
 
     await chatRoomRef.doc(chatRoomInfo.chatRoomId).set(chatRoomInfo.toJson());
-
-    print("아지랑이 32 : ${chatRoomInfo.chatRoomId}");
   }
 
   @override
@@ -57,16 +55,10 @@ final class ChatRemoteDataSourceImpl implements ChatRemoteDataSource {
             toFirestore: (model, _) => model.toJson(),
           );
 
-      print("아지랑이 32 : ${chatRoomId}");
-
       for (var message in messages) {
         await chatRoomRef.doc(message.id).set(message);
-        print('추가됨');
       }
-      print('성공');
-    } catch (e) {
-      print('실패 이유: ${e}');
-    }
+    } catch (e) {}
   }
 
   @override

--- a/lib/features/chat/use_cases/update_chat_info_use_case.dart
+++ b/lib/features/chat/use_cases/update_chat_info_use_case.dart
@@ -22,9 +22,8 @@ class UpdateChatInfoUseCase extends BaseUseCase<UpdateChatInfoParam, void> {
   @override
   Future<void> call(UpdateChatInfoParam request) {
     if (request.answerState.isInitial) {
-      print('에임 1');
       final initialRoomInfo = ChatRoomEntity(
-        interviewerInfo: InterviewerAvatar.getRandomInterviewer(),
+        interviewerInfo: request.interviewer!,
         topic: request.topic,
         chatRoomId: request.chatRoomId,
         lastChatDate: DateTime.now(),
@@ -60,4 +59,5 @@ typedef UpdateChatInfoParam = ({
   AnswerState answerState,
   InterviewTopic topic,
   ChatQnaProgressInfoEntity? qnaProgressInfo,
+  InterviewerAvatar? interviewer,
 });

--- a/lib/features/interview/interview.dart
+++ b/lib/features/interview/interview.dart
@@ -6,9 +6,9 @@ import 'package:techtalk/features/interview/usecases/get_interview_topic_list_us
 import 'package:techtalk/features/interview/usecases/get_review_note_question_list_use_case.dart';
 
 export 'data/local/interview_local_data_source.dart';
+export 'data/remote/interview_remote_data_source.dart';
 export 'repositories/interview_repository.dart';
 export 'usecases/get_interview_topic_list_use_case.dart';
-export 'data/remote/interview_remote_data_source.dart';
 
 final interviewRemoteDataSource = locator<InterviewRemoteDataSource>();
 final interviewLocalDataSource = locator<InterviewLocalDataSource>();

--- a/lib/features/interview/repositories/interview_repository.dart
+++ b/lib/features/interview/repositories/interview_repository.dart
@@ -2,7 +2,7 @@ import 'package:techtalk/core/utils/result.dart';
 import 'package:techtalk/features/chat/chat.dart';
 
 abstract interface class InterviewRepository {
-  List<InterviewTopic> getTopics();
+  Result<List<InterviewTopic>> getTopics();
 
   Future<Result<List<InterviewQnAEntity>>> getReviewNoteQuestions({
     required String userUid,

--- a/lib/features/interview/repositories/interview_repository_impl.dart
+++ b/lib/features/interview/repositories/interview_repository_impl.dart
@@ -12,8 +12,13 @@ class InterviewRepositoryImpl implements InterviewRepository {
   final InterviewRemoteDataSource _interviewRemoteDataSource;
 
   @override
-  List<InterviewTopic> getTopics() {
-    return _interviewLocalDataSource.getTopics();
+  Result<List<InterviewTopic>> getTopics() {
+    try {
+      final response = _interviewLocalDataSource.getTopics();
+      return Result.success(response);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
   }
 
   @override

--- a/lib/features/interview/usecases/get_interview_topic_list_use_case.dart
+++ b/lib/features/interview/usecases/get_interview_topic_list_use_case.dart
@@ -1,14 +1,38 @@
+import 'package:techtalk/core/utils/base/base_no_param_use_case.dart';
+import 'package:techtalk/core/utils/result.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/interview/interview.dart';
+import 'package:techtalk/features/user/repositories/user_repository.dart';
 
-final class GetInterviewTopicListUseCase {
-  const GetInterviewTopicListUseCase(
-    this._interviewRepository,
-  );
+///
+/// 면접 주제 리스트 호출.
+/// 전체 면접 주제들중에 유저의 테크 주제 리스트를 우선적으로 정렬하여 보여줌
+///
+final class GetInterviewTopicListUseCase
+    extends BaseNoParamUseCase<Result<List<InterviewTopic>>> {
+  GetInterviewTopicListUseCase({
+    required InterviewRepository interviewRepository,
+    required UserRepository userRepository,
+  })  : _userRepository = userRepository,
+        _interviewRepository = interviewRepository;
 
   final InterviewRepository _interviewRepository;
+  final UserRepository _userRepository;
 
-  Future<List<InterviewTopic>> call() async {
-    return _interviewRepository.getTopics();
+  @override
+  Future<Result<List<InterviewTopic>>> call() async {
+    final userTopicIdsRes = await _userRepository.getUserTopicList();
+    final userTopicIds = userTopicIdsRes.getOrThrow();
+
+    final topics = _interviewRepository.getTopics().getOrThrow().toList();
+
+    for (InterviewTopic topic in userTopicIds) {
+      if (topics.contains(topic)) {
+        topics.remove(topic);
+        topics.insert(0, topic);
+      }
+    }
+
+    return Result.success(topics);
   }
 }

--- a/lib/features/user/data/models/user_data_model.dart
+++ b/lib/features/user/data/models/user_data_model.dart
@@ -9,8 +9,8 @@ class UserDataModel with _$UserDataModel {
   const factory UserDataModel({
     required String uid,
     String? nickname,
-    List<String>? interestedJobGroupIdList,
-    List<String>? techSkillIdList,
+    List<String>? jobGroupIds,
+    List<String>? topicIds,
   }) = _UserDataModel;
 
   const UserDataModel._();
@@ -18,8 +18,8 @@ class UserDataModel with _$UserDataModel {
   Map<String, dynamic> toFirestore() {
     return {
       'nickname': nickname,
-      'interestedJobGroupIdList': interestedJobGroupIdList,
-      'techSkillIdList': techSkillIdList,
+      'jobGroupIds': jobGroupIds,
+      'topicIds': topicIds,
     };
   }
 

--- a/lib/features/user/data/models/user_data_model.freezed.dart
+++ b/lib/features/user/data/models/user_data_model.freezed.dart
@@ -22,9 +22,8 @@ UserDataModel _$UserDataModelFromJson(Map<String, dynamic> json) {
 mixin _$UserDataModel {
   String get uid => throw _privateConstructorUsedError;
   String? get nickname => throw _privateConstructorUsedError;
-  List<String>? get interestedJobGroupIdList =>
-      throw _privateConstructorUsedError;
-  List<String>? get techSkillIdList => throw _privateConstructorUsedError;
+  List<String>? get jobGroupIds => throw _privateConstructorUsedError;
+  List<String>? get topicIds => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -41,8 +40,8 @@ abstract class $UserDataModelCopyWith<$Res> {
   $Res call(
       {String uid,
       String? nickname,
-      List<String>? interestedJobGroupIdList,
-      List<String>? techSkillIdList});
+      List<String>? jobGroupIds,
+      List<String>? topicIds});
 }
 
 /// @nodoc
@@ -60,8 +59,8 @@ class _$UserDataModelCopyWithImpl<$Res, $Val extends UserDataModel>
   $Res call({
     Object? uid = null,
     Object? nickname = freezed,
-    Object? interestedJobGroupIdList = freezed,
-    Object? techSkillIdList = freezed,
+    Object? jobGroupIds = freezed,
+    Object? topicIds = freezed,
   }) {
     return _then(_value.copyWith(
       uid: null == uid
@@ -72,13 +71,13 @@ class _$UserDataModelCopyWithImpl<$Res, $Val extends UserDataModel>
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String?,
-      interestedJobGroupIdList: freezed == interestedJobGroupIdList
-          ? _value.interestedJobGroupIdList
-          : interestedJobGroupIdList // ignore: cast_nullable_to_non_nullable
+      jobGroupIds: freezed == jobGroupIds
+          ? _value.jobGroupIds
+          : jobGroupIds // ignore: cast_nullable_to_non_nullable
               as List<String>?,
-      techSkillIdList: freezed == techSkillIdList
-          ? _value.techSkillIdList
-          : techSkillIdList // ignore: cast_nullable_to_non_nullable
+      topicIds: freezed == topicIds
+          ? _value.topicIds
+          : topicIds // ignore: cast_nullable_to_non_nullable
               as List<String>?,
     ) as $Val);
   }
@@ -95,8 +94,8 @@ abstract class _$$UserDataModelImplCopyWith<$Res>
   $Res call(
       {String uid,
       String? nickname,
-      List<String>? interestedJobGroupIdList,
-      List<String>? techSkillIdList});
+      List<String>? jobGroupIds,
+      List<String>? topicIds});
 }
 
 /// @nodoc
@@ -112,8 +111,8 @@ class __$$UserDataModelImplCopyWithImpl<$Res>
   $Res call({
     Object? uid = null,
     Object? nickname = freezed,
-    Object? interestedJobGroupIdList = freezed,
-    Object? techSkillIdList = freezed,
+    Object? jobGroupIds = freezed,
+    Object? topicIds = freezed,
   }) {
     return _then(_$UserDataModelImpl(
       uid: null == uid
@@ -124,13 +123,13 @@ class __$$UserDataModelImplCopyWithImpl<$Res>
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String?,
-      interestedJobGroupIdList: freezed == interestedJobGroupIdList
-          ? _value._interestedJobGroupIdList
-          : interestedJobGroupIdList // ignore: cast_nullable_to_non_nullable
+      jobGroupIds: freezed == jobGroupIds
+          ? _value._jobGroupIds
+          : jobGroupIds // ignore: cast_nullable_to_non_nullable
               as List<String>?,
-      techSkillIdList: freezed == techSkillIdList
-          ? _value._techSkillIdList
-          : techSkillIdList // ignore: cast_nullable_to_non_nullable
+      topicIds: freezed == topicIds
+          ? _value._topicIds
+          : topicIds // ignore: cast_nullable_to_non_nullable
               as List<String>?,
     ));
   }
@@ -142,10 +141,10 @@ class _$UserDataModelImpl extends _UserDataModel {
   const _$UserDataModelImpl(
       {required this.uid,
       this.nickname,
-      final List<String>? interestedJobGroupIdList,
-      final List<String>? techSkillIdList})
-      : _interestedJobGroupIdList = interestedJobGroupIdList,
-        _techSkillIdList = techSkillIdList,
+      final List<String>? jobGroupIds,
+      final List<String>? topicIds})
+      : _jobGroupIds = jobGroupIds,
+        _topicIds = topicIds,
         super._();
 
   factory _$UserDataModelImpl.fromJson(Map<String, dynamic> json) =>
@@ -155,30 +154,29 @@ class _$UserDataModelImpl extends _UserDataModel {
   final String uid;
   @override
   final String? nickname;
-  final List<String>? _interestedJobGroupIdList;
+  final List<String>? _jobGroupIds;
   @override
-  List<String>? get interestedJobGroupIdList {
-    final value = _interestedJobGroupIdList;
+  List<String>? get jobGroupIds {
+    final value = _jobGroupIds;
     if (value == null) return null;
-    if (_interestedJobGroupIdList is EqualUnmodifiableListView)
-      return _interestedJobGroupIdList;
+    if (_jobGroupIds is EqualUnmodifiableListView) return _jobGroupIds;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
 
-  final List<String>? _techSkillIdList;
+  final List<String>? _topicIds;
   @override
-  List<String>? get techSkillIdList {
-    final value = _techSkillIdList;
+  List<String>? get topicIds {
+    final value = _topicIds;
     if (value == null) return null;
-    if (_techSkillIdList is EqualUnmodifiableListView) return _techSkillIdList;
+    if (_topicIds is EqualUnmodifiableListView) return _topicIds;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(value);
   }
 
   @override
   String toString() {
-    return 'UserDataModel(uid: $uid, nickname: $nickname, interestedJobGroupIdList: $interestedJobGroupIdList, techSkillIdList: $techSkillIdList)';
+    return 'UserDataModel(uid: $uid, nickname: $nickname, jobGroupIds: $jobGroupIds, topicIds: $topicIds)';
   }
 
   @override
@@ -189,10 +187,9 @@ class _$UserDataModelImpl extends _UserDataModel {
             (identical(other.uid, uid) || other.uid == uid) &&
             (identical(other.nickname, nickname) ||
                 other.nickname == nickname) &&
-            const DeepCollectionEquality().equals(
-                other._interestedJobGroupIdList, _interestedJobGroupIdList) &&
             const DeepCollectionEquality()
-                .equals(other._techSkillIdList, _techSkillIdList));
+                .equals(other._jobGroupIds, _jobGroupIds) &&
+            const DeepCollectionEquality().equals(other._topicIds, _topicIds));
   }
 
   @JsonKey(ignore: true)
@@ -201,8 +198,8 @@ class _$UserDataModelImpl extends _UserDataModel {
       runtimeType,
       uid,
       nickname,
-      const DeepCollectionEquality().hash(_interestedJobGroupIdList),
-      const DeepCollectionEquality().hash(_techSkillIdList));
+      const DeepCollectionEquality().hash(_jobGroupIds),
+      const DeepCollectionEquality().hash(_topicIds));
 
   @JsonKey(ignore: true)
   @override
@@ -222,8 +219,8 @@ abstract class _UserDataModel extends UserDataModel {
   const factory _UserDataModel(
       {required final String uid,
       final String? nickname,
-      final List<String>? interestedJobGroupIdList,
-      final List<String>? techSkillIdList}) = _$UserDataModelImpl;
+      final List<String>? jobGroupIds,
+      final List<String>? topicIds}) = _$UserDataModelImpl;
   const _UserDataModel._() : super._();
 
   factory _UserDataModel.fromJson(Map<String, dynamic> json) =
@@ -234,9 +231,9 @@ abstract class _UserDataModel extends UserDataModel {
   @override
   String? get nickname;
   @override
-  List<String>? get interestedJobGroupIdList;
+  List<String>? get jobGroupIds;
   @override
-  List<String>? get techSkillIdList;
+  List<String>? get topicIds;
   @override
   @JsonKey(ignore: true)
   _$$UserDataModelImplCopyWith<_$UserDataModelImpl> get copyWith =>

--- a/lib/features/user/data/models/user_data_model.g.dart
+++ b/lib/features/user/data/models/user_data_model.g.dart
@@ -10,11 +10,10 @@ _$UserDataModelImpl _$$UserDataModelImplFromJson(Map<String, dynamic> json) =>
     _$UserDataModelImpl(
       uid: json['uid'] as String,
       nickname: json['nickname'] as String?,
-      interestedJobGroupIdList:
-          (json['interestedJobGroupIdList'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList(),
-      techSkillIdList: (json['techSkillIdList'] as List<dynamic>?)
+      jobGroupIds: (json['jobGroupIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      topicIds: (json['topicIds'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
     );
@@ -23,6 +22,6 @@ Map<String, dynamic> _$$UserDataModelImplToJson(_$UserDataModelImpl instance) =>
     <String, dynamic>{
       'uid': instance.uid,
       'nickname': instance.nickname,
-      'interestedJobGroupIdList': instance.interestedJobGroupIdList,
-      'techSkillIdList': instance.techSkillIdList,
+      'jobGroupIds': instance.jobGroupIds,
+      'topicIds': instance.topicIds,
     };

--- a/lib/features/user/entities/user_data_entity.dart
+++ b/lib/features/user/entities/user_data_entity.dart
@@ -20,14 +20,14 @@ class UserDataEntity with _$UserDataEntity {
   UserDataModel toModel() => UserDataModel(
         uid: uid,
         nickname: nickname,
-        interestedJobGroupIdList: interestedJobGroupIdList,
-        techSkillIdList: techSkillIdList,
+        jobGroupIds: interestedJobGroupIdList,
+        topicIds: techSkillIdList,
       );
   factory UserDataEntity.fromModel(UserDataModel model) => UserDataEntity(
         uid: model.uid,
         nickname: model.nickname,
-        interestedJobGroupIdList: model.interestedJobGroupIdList ?? [],
-        techSkillIdList: model.techSkillIdList ?? [],
+        interestedJobGroupIdList: model.jobGroupIds ?? [],
+        techSkillIdList: model.topicIds ?? [],
       );
   factory UserDataEntity.fromJson(Map<String, dynamic> json) =>
       _$UserDataEntityFromJson(json);

--- a/lib/features/user/repositories/user_repository.dart
+++ b/lib/features/user/repositories/user_repository.dart
@@ -1,7 +1,10 @@
+import 'package:techtalk/core/utils/result.dart';
+import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/user/entities/user_data_entity.dart';
 
 abstract interface class UserRepository {
   Future<void> createUserData(UserDataEntity data);
   Future<UserDataEntity?> getUserData(String uid);
+  Future<Result<List<InterviewTopic>>> getUserTopicList();
   Future<bool> isExistNickname(String nickname);
 }

--- a/lib/features/user/repositories/user_repository_impl.dart
+++ b/lib/features/user/repositories/user_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'package:techtalk/core/utils/result.dart';
+import 'package:techtalk/features/chat/repositories/enums/interview_topic.enum.dart';
 import 'package:techtalk/features/user/data/remote/user_remote_data_source.dart';
 import 'package:techtalk/features/user/entities/user_data_entity.dart';
 import 'package:techtalk/features/user/repositories/user_repository.dart';
@@ -33,5 +35,21 @@ final class UserRepositoryImpl implements UserRepository {
   @override
   Future<bool> isExistNickname(String nickname) {
     return _userRemoteDataSource.isExistNickname(nickname);
+  }
+
+  @override
+  Future<Result<List<InterviewTopic>>> getUserTopicList() async {
+    try {
+      const userLocalId = '2FXrROIad2RSKt37NA8tciQx7e53'; // TEMP
+      final response = await _userRemoteDataSource.getUserData(userLocalId);
+
+      final topicIds = response?.topicIds ?? [];
+
+      final result = topicIds.map(InterviewTopic.getTopicById).toList();
+
+      return Result.success(result);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
   }
 }

--- a/lib/presentation/pages/home/home_event.dart
+++ b/lib/presentation/pages/home/home_event.dart
@@ -1,13 +1,12 @@
-import 'package:flutter/material.dart';
 import 'package:techtalk/app/router/router.dart';
 
 abstract interface class _HomeEvent {
-  void onTapNewTopicInterview(BuildContext context);
+  void onTapNewTopicInterview();
 }
 
 mixin class HomeEvent implements _HomeEvent {
   @override
-  void onTapNewTopicInterview(BuildContext context) {
-    const HomeTopicSelectRoute().push(context);
+  void onTapNewTopicInterview() {
+    const HomeTopicSelectRoute().push(rootNavigatorKey.currentContext!);
   }
 }

--- a/lib/presentation/pages/home/widgets/topic_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/topic_interview_card.dart
@@ -10,44 +10,49 @@ class TopicInterviewCard extends StatelessWidget with HomeEvent {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: EdgeInsets.symmetric(horizontal: 16),
-      padding: EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  '주제별 면접',
-                  style: AppTextStyle.headline2,
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: MaterialButton(
+        color: AppColor.of.white,
+        elevation: 0,
+        padding: const EdgeInsets.all(24),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        minWidth: 0,
+        onPressed: onTapNewTopicInterview,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '주제별 면접',
+                    style: AppTextStyle.headline2,
+                  ),
                 ),
-              ),
-              WidthBox(48),
-              GestureDetector(
-                onTap: () => onTapNewTopicInterview(context),
-                child: FaIcon(
-                  FontAwesomeIcons.circlePlus,
-                  color: AppColor.of.brand2,
-                  size: 24,
+                WidthBox(48),
+                GestureDetector(
+                  onTap: onTapNewTopicInterview,
+                  child: FaIcon(
+                    FontAwesomeIcons.circlePlus,
+                    color: AppColor.of.brand2,
+                    size: 24,
+                  ),
                 ),
-              ),
-            ],
-          ),
-          HeightBox(12),
-          // TODO : 면접을 하나라도 진행하면 텍스트 대신 해당 면접 표시
-          Text(
-            '하나의 주제를 선택해 집중 공략해 보세요!',
-            style: AppTextStyle.body1.copyWith(
-              color: AppColor.of.gray3,
+              ],
             ),
-          ),
-        ],
+            HeightBox(12),
+            // TODO : 면접을 하나라도 진행하면 텍스트 대신 해당 면접 표시
+            Text(
+              '하나의 주제를 선택해 집중 공략해 보세요!',
+              style: AppTextStyle.body1.copyWith(
+                color: AppColor.of.gray3,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/pages/interview/chat/providers/chat_history_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_history_provider.dart
@@ -188,6 +188,7 @@ class ChatHistory extends _$ChatHistory {
           .extractElementsBefore(state.requireValue.firstWhere(
         (message) => message.type.isSentMessage,
       )),
+      interviewer: null,
       answerState: answerState,
       chatRoomId: ref.read(chatPageRouteArgProvider).roomId,
       topic: ref.read(chatPageRouteArgProvider).topic,
@@ -213,6 +214,7 @@ class ChatHistory extends _$ChatHistory {
       answerState: answerState,
       chatRoomId: ref.read(chatPageRouteArgProvider).roomId,
       topic: ref.read(chatPageRouteArgProvider).topic,
+      interviewer: null,
       qnaProgressInfo: null,
     );
     await updateChatInfoUseCase.call(param);
@@ -228,6 +230,7 @@ class ChatHistory extends _$ChatHistory {
       answerState: AnswerState.initial,
       chatRoomId: ref.read(chatPageRouteArgProvider).roomId,
       topic: ref.read(chatPageRouteArgProvider).topic,
+      interviewer: ref.read(chatPageRouteArgProvider).interviewer,
       qnaProgressInfo: ref.read(chatPageRouteArgProvider).qnaProgressInfo,
     );
     await updateChatInfoUseCase(param);

--- a/lib/presentation/pages/interview/chat/providers/chat_history_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_history_provider.g.dart
@@ -6,7 +6,7 @@ part of 'chat_history_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatHistoryHash() => r'847f1c0b10b6aca645e5abbbbf535751230d65a5';
+String _$chatHistoryHash() => r'96857c4195664bc2823859fe3a102546557f2a51';
 
 /// See also [ChatHistory].
 @ProviderFor(ChatHistory)

--- a/lib/presentation/pages/interview/questino_count_select/provider/question_count_select_page_route_arg_provider.dart
+++ b/lib/presentation/pages/interview/questino_count_select/provider/question_count_select_page_route_arg_provider.dart
@@ -1,0 +1,9 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:techtalk/features/chat/chat.dart';
+
+part 'question_count_select_page_route_arg_provider.g.dart';
+
+@riverpod
+InterviewTopic questionCountSelectRouteArg(QuestionCountSelectRouteArgRef ref) {
+  throw Exception('Question Count Select Page : argument missed');
+}

--- a/lib/presentation/pages/interview/questino_count_select/provider/question_count_select_page_route_arg_provider.g.dart
+++ b/lib/presentation/pages/interview/questino_count_select/provider/question_count_select_page_route_arg_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'question_count_select_page_route_arg_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$questionCountSelectRouteArgHash() =>
+    r'269ab54d570ad492b99f03159ac6f8d5c5c6c1ed';
+
+/// See also [questionCountSelectRouteArg].
+@ProviderFor(questionCountSelectRouteArg)
+final questionCountSelectRouteArgProvider =
+    AutoDisposeProvider<InterviewTopic>.internal(
+  questionCountSelectRouteArg,
+  name: r'questionCountSelectRouteArgProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$questionCountSelectRouteArgHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef QuestionCountSelectRouteArgRef = AutoDisposeProviderRef<InterviewTopic>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/interview/questino_count_select/provider/selected_question_count_provider.dart
+++ b/lib/presentation/pages/interview/questino_count_select/provider/selected_question_count_provider.dart
@@ -1,0 +1,15 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'selected_question_count_provider.g.dart';
+
+@riverpod
+class SelectedQuestionCount extends _$SelectedQuestionCount {
+  @override
+  int build() {
+    return 8;
+  }
+
+  void onCountPickerChanged(int count) {
+    state = count;
+  }
+}

--- a/lib/presentation/pages/interview/questino_count_select/provider/selected_question_count_provider.g.dart
+++ b/lib/presentation/pages/interview/questino_count_select/provider/selected_question_count_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'selected_question_count_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$selectedQuestionCountHash() =>
+    r'55841e1eb291b7acafff25eaaeaf0f33c47c19ed';
+
+/// See also [SelectedQuestionCount].
+@ProviderFor(SelectedQuestionCount)
+final selectedQuestionCountProvider =
+    AutoDisposeNotifierProvider<SelectedQuestionCount, int>.internal(
+  SelectedQuestionCount.new,
+  name: r'selectedQuestionCountProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$selectedQuestionCountHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$SelectedQuestionCount = AutoDisposeNotifier<int>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/interview/questino_count_select/question_count_select_event.dart
+++ b/lib/presentation/pages/interview/questino_count_select/question_count_select_event.dart
@@ -1,0 +1,32 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/core/helper/string_generator.dart';
+import 'package:techtalk/features/chat/repositories/entities/chat_qna_progress_info_entity.dart';
+import 'package:techtalk/features/chat/repositories/enums/interview_progress_state.enum.dart';
+import 'package:techtalk/features/shared/enums/interviewer_avatar.dart';
+import 'package:techtalk/presentation/pages/interview/questino_count_select/provider/question_count_select_page_route_arg_provider.dart';
+import 'package:techtalk/presentation/pages/interview/questino_count_select/provider/selected_question_count_provider.dart';
+
+abstract class _QuestionCountSelectEvent {
+  void routeToChatPage(WidgetRef ref);
+}
+
+mixin class QuestionCountSelectedEvent implements _QuestionCountSelectEvent {
+  @override
+  void routeToChatPage(WidgetRef ref) {
+    final aim =  InterviewerAvatar.getRandomInterviewer();
+    ChatPageRoute(
+      progressState: InterviewProgressState.initial,
+      roomId: StringGenerator.generateRandomString(),
+      topic: ref.read(questionCountSelectRouteArgProvider),
+      $extra: ChatQnaProgressInfoEntity.onInitial(
+        totalQuestionCount: ref.watch(selectedQuestionCountProvider),
+      ),
+      interviewer: aim,
+    ).go(rootNavigatorKey.currentContext!);
+
+    print('선택된 캐릭터 : ${aim.id}');
+  }
+
+
+}

--- a/lib/presentation/pages/interview/questino_count_select/question_count_select_page.dart
+++ b/lib/presentation/pages/interview/questino_count_select/question_count_select_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/src/consumer.dart';
+import 'package:techtalk/core/services/size_service.dart';
+import 'package:techtalk/core/theme/extension/app_text_style.dart';
+import 'package:techtalk/presentation/pages/interview/questino_count_select/provider/selected_question_count_provider.dart';
+import 'package:techtalk/presentation/pages/interview/questino_count_select/question_count_select_event.dart';
+import 'package:techtalk/presentation/widgets/base/base_page.dart';
+import 'package:techtalk/presentation/widgets/common/app_bar/back_button_app_bar.dart';
+import 'package:techtalk/presentation/widgets/common/box/empty_box.dart';
+
+class QuestionCountSelectPage extends BasePage {
+  const QuestionCountSelectPage({Key? key}) : super(key: key);
+
+  @override
+  Widget buildPage(BuildContext context, WidgetRef ref) {
+    List<int> options = List.generate(18, (index) => index + 3); // 3 ~ 20
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const HeightBox(20),
+          _buildLeadingMessage(),
+          Expanded(
+            child: Center(
+              child: SizedBox(
+                height: AppSize.to.screenHeight * 0.6,
+                child: CupertinoPicker.builder(
+                  scrollController: FixedExtentScrollController(
+                    initialItem: options
+                        .indexOf(ref.watch(selectedQuestionCountProvider)),
+                  ),
+                  useMagnifier: true,
+                  magnification: 1.22,
+                  squeeze: 1.2,
+                  itemExtent: 35,
+                  childCount: options.length,
+                  onSelectedItemChanged: (value) {
+                    final selectedCount = options[value];
+                    ref
+                        .read(selectedQuestionCountProvider.notifier)
+                        .onCountPickerChanged(selectedCount);
+                  },
+                  itemBuilder: (context, index) {
+                    return Text(
+                      options[index].toString(),
+                      style: const TextStyle(
+                        fontSize: 24,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+          const _StartInterviewBtn(),
+        ],
+      ),
+    );
+  }
+
+  @override
+  PreferredSizeWidget? buildAppBar(BuildContext context) =>
+      const BackButtonAppBar();
+
+  Widget _buildLeadingMessage() {
+    return Text(
+      '면접 질문 개수를\n선택해주세요',
+      style: AppTextStyle.headline1,
+    );
+  }
+}
+
+class _StartInterviewBtn extends ConsumerWidget
+    with QuestionCountSelectedEvent {
+  const _StartInterviewBtn({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return FilledButton(
+      onPressed: () {
+        routeToChatPage(ref);
+      },
+      child: const Center(
+        child: Text('시작하기'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/interview/topic_select/interview_topic_select_event.dart
+++ b/lib/presentation/pages/interview/topic_select/interview_topic_select_event.dart
@@ -1,0 +1,19 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/presentation/pages/interview/topic_select/providers/selected_topic_provider.dart';
+
+abstract class _InterviewTopicSelectEvent {
+  ///
+  /// 면접 문제 개수 페이지로 이동
+  ///
+  void routeToQuestionCountSelect(WidgetRef ref);
+}
+
+mixin class InterviewTopicSelectEvent implements _InterviewTopicSelectEvent {
+  @override
+  void routeToQuestionCountSelect(WidgetRef ref) {
+    final selectedTopic = ref.watch(selectedTopicProvider);
+    QuestionCountSelectPageRoute(selectedTopic: selectedTopic!)
+        .go(rootNavigatorKey.currentContext!);
+  }
+}

--- a/lib/presentation/pages/interview/topic_select/interview_topic_select_page.dart
+++ b/lib/presentation/pages/interview/topic_select/interview_topic_select_page.dart
@@ -1,103 +1,106 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/core/theme/extension/app_text_style.dart';
+import 'package:techtalk/presentation/pages/interview/topic_select/interview_topic_select_event.dart';
+import 'package:techtalk/presentation/pages/interview/topic_select/providers/selected_topic_provider.dart';
 import 'package:techtalk/presentation/pages/interview/topic_select/providers/topic_list_provider.dart';
 import 'package:techtalk/presentation/pages/interview/topic_select/widgets/topic_card.dart';
+import 'package:techtalk/presentation/pages/interview/topic_select/widgets/topic_grid_view_builder.dart';
+import 'package:techtalk/presentation/widgets/base/base_page.dart';
+import 'package:techtalk/presentation/widgets/common/app_bar/back_button_app_bar.dart';
+import 'package:techtalk/presentation/widgets/common/box/empty_box.dart';
 
-class InterviewTopicSelectPage extends StatelessWidget {
+class InterviewTopicSelectPage extends BasePage with InterviewTopicSelectEvent {
   const InterviewTopicSelectPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(),
-      body: const _Body(),
-    );
-  }
-}
-
-class _Body extends HookWidget {
-  const _Body({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final selectedTopic = useState<int?>(null);
-
-    return SafeArea(
-      minimum: EdgeInsets.only(bottom: 16),
+  Widget buildPage(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+        children: <Widget>[
+          const HeightBox(20),
           _buildInfoMessage(),
-          _buildTopicListView(selectedTopic),
-          _buildNextButton(selectedTopic),
+          const _TopicListView(),
+          const _NextButton(),
         ],
       ),
     );
   }
 
+  @override
+  PreferredSizeWidget? buildAppBar(BuildContext context) =>
+      const BackButtonAppBar();
+
   Widget _buildInfoMessage() {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 16),
-      child: Text(
-        'AI 면접을 진행할\n주제를 알려주세요',
-        style: AppTextStyle.headline1,
+    return Text(
+      'AI 면접을 진행할\n주제를 알려주세요',
+      style: AppTextStyle.headline1,
+    );
+  }
+}
+
+class _NextButton extends ConsumerWidget with InterviewTopicSelectEvent {
+  const _NextButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return FilledButton(
+      onPressed: ref.watch(selectedTopicProvider) != null
+          ? () {
+              routeToQuestionCountSelect(ref);
+            }
+          : null,
+      child: const Center(
+        child: Text('다음'),
       ),
     );
   }
+}
 
-  Widget _buildTopicListView(ValueNotifier<int?> selectedTopic) {
+class _TopicListView extends ConsumerWidget {
+  const _TopicListView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     return Expanded(
       child: Container(
-        padding: EdgeInsets.fromLTRB(16, 24, 16, 16),
+        padding: const EdgeInsets.only(top: 24, bottom: 16),
         child: Consumer(
           builder: (context, ref, child) {
             final topicListAsync = ref.watch(topicListProvider);
 
             return topicListAsync.when(
-              loading: SizedBox.new,
-              error: (error, stackTrace) => Text('$error'),
               data: (data) {
-                return GridView.builder(
-                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    crossAxisSpacing: 11,
-                    mainAxisSpacing: 12,
-                  ),
+                return TopicGridViewBuilder(
                   itemCount: data.length,
                   itemBuilder: (context, index) {
                     final topic = data[index];
-                    final isSelected = index == selectedTopic.value;
 
                     return TopicCard(
                       topic: topic,
-                      isSelected: isSelected,
+                      isSelected: ref.watch(selectedTopicProvider) == topic,
                       onTap: () {
-                        if (isSelected) {
-                          selectedTopic.value = null;
-                        } else {
-                          selectedTopic.value = index;
-                        }
+                        ref
+                            .read(selectedTopicProvider.notifier)
+                            .onTopicSelected(topic);
                       },
                     );
                   },
                 );
               },
+              loading: () {
+                return TopicGridViewBuilder(
+                  itemCount: 10,
+                  itemBuilder: (_, __) {
+                    return TopicCard.createSkeleton();
+                  },
+                );
+              },
+              error: (error, stackTrace) => Text('$error'),
             );
           },
-        ),
-      ),
-    );
-  }
-
-  Widget _buildNextButton(ValueNotifier<int?> selectedTopic) {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 16),
-      child: FilledButton(
-        onPressed: selectedTopic.value != null ? () {} : null,
-        child: Center(
-          child: Text('다음'),
         ),
       ),
     );

--- a/lib/presentation/pages/interview/topic_select/providers/selected_topic_provider.dart
+++ b/lib/presentation/pages/interview/topic_select/providers/selected_topic_provider.dart
@@ -1,0 +1,25 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:techtalk/features/chat/chat.dart';
+
+part 'selected_topic_provider.g.dart';
+
+@riverpod
+class SelectedTopic extends _$SelectedTopic {
+  @override
+  InterviewTopic? build() {
+    return null;
+  }
+
+  ///
+  /// 면접 주제가 선택되었을 때
+  ///
+  void onTopicSelected(InterviewTopic passedTopic) {
+    final isSelected = passedTopic == state;
+
+    if (isSelected) {
+      state = null;
+    } else {
+      state = passedTopic;
+    }
+  }
+}

--- a/lib/presentation/pages/interview/topic_select/providers/selected_topic_provider.g.dart
+++ b/lib/presentation/pages/interview/topic_select/providers/selected_topic_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'selected_topic_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$selectedTopicHash() => r'fb271c761c6f2fb5a7e3abf44a95a02e3c9a881f';
+
+/// See also [SelectedTopic].
+@ProviderFor(SelectedTopic)
+final selectedTopicProvider =
+    AutoDisposeNotifierProvider<SelectedTopic, InterviewTopic?>.internal(
+  SelectedTopic.new,
+  name: r'selectedTopicProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$selectedTopicHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$SelectedTopic = AutoDisposeNotifier<InterviewTopic?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/interview/topic_select/providers/topic_list_provider.dart
+++ b/lib/presentation/pages/interview/topic_select/providers/topic_list_provider.dart
@@ -1,13 +1,28 @@
+import 'dart:developer';
+
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:techtalk/core/services/toast_service.dart';
 import 'package:techtalk/features/chat/repositories/enums/interview_topic.enum.dart';
 import 'package:techtalk/features/interview/interview.dart';
+import 'package:techtalk/presentation/widgets/common/common.dart';
 
 part 'topic_list_provider.g.dart';
 
 @riverpod
-Future<List<InterviewTopic>> topicList(TopicListRef ref) async {
-  await Future.delayed(3.seconds);
+FutureOr<List<InterviewTopic>> topicList(TopicListRef ref) async {
+  await Future.delayed(1.seconds);
 
-  return getInterviewTopicListUseCase();
+  final response = await getInterviewTopicListUseCase();
+
+  return response.fold(
+    onSuccess: (topics) {
+      return topics;
+    },
+    onFailure: (e) {
+      ToastService.show(CustomToast(message: e.toString()));
+      log(e.toString());
+      throw e;
+    },
+  );
 }

--- a/lib/presentation/pages/interview/topic_select/providers/topic_list_provider.g.dart
+++ b/lib/presentation/pages/interview/topic_select/providers/topic_list_provider.g.dart
@@ -6,7 +6,7 @@ part of 'topic_list_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$topicListHash() => r'f5ab67c2e1084f75ac42dc52c634c74714f42fbb';
+String _$topicListHash() => r'9a3c211fd4fd67a1489eee15c2b75127f4cd01ff';
 
 /// See also [topicList].
 @ProviderFor(topicList)

--- a/lib/presentation/pages/interview/topic_select/widgets/topic_card.dart
+++ b/lib/presentation/pages/interview/topic_select/widgets/topic_card.dart
@@ -9,12 +9,19 @@ class TopicCard extends StatelessWidget {
     super.key,
     required this.topic,
     this.isSelected = false,
+    this.isLoaded = true,
     this.onTap,
   });
 
-  final InterviewTopic topic;
+  final InterviewTopic? topic;
   final bool isSelected;
   final VoidCallback? onTap;
+  final bool isLoaded;
+
+  factory TopicCard.createSkeleton() => const TopicCard(
+        topic: null,
+        isLoaded: false,
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -31,34 +38,37 @@ class TopicCard extends StatelessWidget {
       ),
       child: InkWell(
         borderRadius: BorderRadius.circular(16),
-        onTap: onTap,
+        onTap: isLoaded ? onTap : null,
         child: Padding(
-          padding: EdgeInsets.all(28),
-          child: Column(
-            children: [
-              Expanded(
-                child: Image.asset(
-                  topic.imageUrl!,
-                  color:
-                      isSelected ? AppColor.of.brand2.withOpacity(0.07) : null,
-                  colorBlendMode: BlendMode.srcATop,
-                  errorBuilder: (_, __, ___) => Center(
-                    child: Container(
-                      decoration: const BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: Colors.white,
+          padding: const EdgeInsets.all(28),
+          child: isLoaded
+              ? Column(
+                  children: [
+                    Expanded(
+                      child: Image.asset(
+                        topic!.imageUrl!,
+                        color: isSelected
+                            ? AppColor.of.brand2.withOpacity(0.07)
+                            : null,
+                        colorBlendMode: BlendMode.srcATop,
+                        errorBuilder: (_, __, ___) => Center(
+                          child: Container(
+                            decoration: const BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ),
-              ),
-              HeightBox(16),
-              Text(
-                topic.name,
-                style: AppTextStyle.headline3,
-              ),
-            ],
-          ),
+                    const HeightBox(16),
+                    Text(
+                      topic!.name,
+                      style: AppTextStyle.headline3,
+                    ),
+                  ],
+                )
+              : const EmptyBox(),
         ),
       ),
     );

--- a/lib/presentation/pages/interview/topic_select/widgets/topic_grid_view_builder.dart
+++ b/lib/presentation/pages/interview/topic_select/widgets/topic_grid_view_builder.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class TopicGridViewBuilder extends StatelessWidget {
+  const TopicGridViewBuilder(
+      {Key? key, required this.itemBuilder, required this.itemCount})
+      : super(key: key);
+
+  final NullableIndexedWidgetBuilder itemBuilder;
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 11,
+        mainAxisSpacing: 12,
+      ),
+      itemCount: itemCount,
+      itemBuilder: itemBuilder,
+    );
+  }
+}

--- a/lib/presentation/pages/study/topic_select/providers/topic_list_provider.dart
+++ b/lib/presentation/pages/study/topic_select/providers/topic_list_provider.dart
@@ -1,7 +1,11 @@
+import 'dart:developer';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:techtalk/app/di/locator.dart';
+import 'package:techtalk/core/services/toast_service.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/interview/interview.dart';
+import 'package:techtalk/presentation/widgets/common/common.dart';
 
 part 'topic_list_provider.g.dart';
 
@@ -11,20 +15,30 @@ Future<Map<String, List<InterviewTopic>>> studyTopicList(
 ) async {
   final getInterviewTopicListUseCase = locator<GetInterviewTopicListUseCase>();
 
-  final topicList = List.of(await getInterviewTopicListUseCase());
-  topicList.sort(
-    (a, b) => a.category.text.compareTo(b.category.text),
+  final response = await getInterviewTopicListUseCase();
+
+  return response.fold(
+    onSuccess: (topicList) {
+      topicList.sort(
+        (a, b) => a.category.text.compareTo(b.category.text),
+      );
+
+      final resolvedTopicList = <String, List<InterviewTopic>>{};
+
+      for (final topic in topicList) {
+        if (resolvedTopicList.containsKey(topic.category.text)) {
+          resolvedTopicList[topic.category.text]!.add(topic);
+        } else {
+          resolvedTopicList[topic.category.text] = [topic];
+        }
+      }
+
+      return resolvedTopicList;
+    },
+    onFailure: (e) {
+      log(e.toString());
+      ToastService.show(CustomToast(message: e.toString()));
+      throw e;
+    },
   );
-
-  final resolvedTopicList = <String, List<InterviewTopic>>{};
-
-  for (final topic in topicList) {
-    if (resolvedTopicList.containsKey(topic.category.text)) {
-      resolvedTopicList[topic.category.text]!.add(topic);
-    } else {
-      resolvedTopicList[topic.category.text] = [topic];
-    }
-  }
-
-  return resolvedTopicList;
 }

--- a/lib/presentation/pages/study/topic_select/providers/topic_list_provider.g.dart
+++ b/lib/presentation/pages/study/topic_select/providers/topic_list_provider.g.dart
@@ -6,7 +6,7 @@ part of 'topic_list_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$studyTopicListHash() => r'c7e5922d5b6066534854edea05390a24b58c75d1';
+String _$studyTopicListHash() => r'6d08f8a91a1c76ab7501fdc3722f83ec1ec96dbd';
 
 /// See also [studyTopicList].
 @ProviderFor(studyTopicList)

--- a/lib/presentation/widgets/common/app_bar/back_button_app_bar.dart
+++ b/lib/presentation/widgets/common/app_bar/back_button_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:techtalk/core/constants/assets.dart';
 import 'package:techtalk/core/theme/extension/app_color.dart';
 import 'package:techtalk/core/theme/extension/app_text_style.dart';
@@ -7,12 +8,12 @@ import 'package:techtalk/core/theme/extension/app_text_style.dart';
 class BackButtonAppBar extends StatelessWidget implements PreferredSizeWidget {
   const BackButtonAppBar({
     super.key,
-    required this.title,
-    required this.onBackBtnTapped,
+    this.title,
+    this.onBackBtnTapped,
   }) : actions = null;
 
   final String? title;
-  final VoidCallback onBackBtnTapped;
+  final VoidCallback? onBackBtnTapped;
   final List<Widget>? actions;
 
   @override
@@ -30,7 +31,7 @@ class BackButtonAppBar extends StatelessWidget implements PreferredSizeWidget {
       ),
       leading: SizedBox(
         child: IconButton(
-          onPressed: onBackBtnTapped,
+          onPressed: onBackBtnTapped ?? context.pop,
           icon: SvgPicture.asset(Assets.iconsArrowLeft),
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -672,6 +672,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  infinite_listview:
+    dependency: transitive
+    description:
+      name: infinite_listview
+      sha256: f6062c1720eb59be553dfa6b89813d3e8dd2f054538445aaa5edaddfa5195ce6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   intl:
     dependency: "direct main"
     description:
@@ -784,6 +792,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  numberpicker:
+    dependency: "direct main"
+    description:
+      name: numberpicker
+      sha256: "4c129154944b0f6b133e693f8749c3f8bfb67c4d07ef9dcab48b595c22d1f156"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   animations: ^2.0.8
   flutter_animate: ^4.2.0+1
 
-
   # 상태관리
   provider: ^6.0.5
   hooks_riverpod: ^2.4.0


### PR DESCRIPTION
## 📝 변경 내용
- 면접 주제 호출 로직 고도화. 유저의 테크 스킬 정보가 있을 경우 해당 주제를 우선적으로 보여주도록 함.
- 면접 주제 선택 페이지 UI 개선 및 state 로직 변경
  - [홈] 주제별 면접 카드 Inkwell 인터렉션 추가
  - 로딩 스켈레톤 UI 추가
  - 공통 앱바 모듈 적용
  - state로직 변경,  hook -> provider (event mixin 모듈을 적용하기 위해)
  - ui 리팩토링 구조 일부 변경. function -> class (event mixin 모듈을 적용하기 위해)
- 문제 개수 선택 페이지 UI 추가
   - 채팅 페이지로 이동하는 라우팅 로직 연동
- UserModel 멤버 변수 네이밍 일부 변경 (조금 간소화)
   

https://github.com/MakeFrog/TechTalk/assets/75591730/727ba442-514c-46a9-b44e-d6ea3bd8ec96




<br>

## 🔍 변경 이유
* 면접 주제 호출 로직 고도화 및 질문 개수 페이지 UI 추가

<br>

## 🌍 영향
없음.

<br>

## 🧪 테스트 계획
없음.

<br>

## 📌 기타 사항
주제 선택 페이지 관련해서 일부 수정한 내용들이 있습니다!
- event mixin 형식을 유지하고 위젯 리빌드를 최소화하기 위해 위해 기존 function으로 추출된  UI 위젯을 class로 변경.
- event mixin에서 state에 좀더 쉽게 접근할 수 있도록 Hook으로 선언된 state 값들을 proviuder로 변경.
(관련해서 피드백 주셔도 좋을 것 같습니다!)

<br>
