### PR TITLE
[공통] 앱 평가 다이어로그 노출 로직 추가 및 일부 인터렉션 개선 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - AppAuth/Core (1.6.2)
   - AppAuth/ExternalUserAgent (1.6.2):
     - AppAuth/Core
-  - cloud_firestore (4.15.5):
+  - cloud_firestore (4.15.6):
     - Firebase/Firestore (= 10.20.0)
     - firebase_core
     - Flutter
@@ -38,18 +38,18 @@ PODS:
     - Firebase/Analytics (= 10.20.0)
     - firebase_core
     - Flutter
-  - firebase_auth (4.17.4):
+  - firebase_auth (4.17.6):
     - Firebase/Auth (= 10.20.0)
     - firebase_core
     - Flutter
   - firebase_core (2.25.5):
     - Firebase/CoreOnly (= 10.20.0)
     - Flutter
-  - firebase_crashlytics (3.4.15):
+  - firebase_crashlytics (3.4.16):
     - Firebase/Crashlytics (= 10.20.0)
     - firebase_core
     - Flutter
-  - firebase_storage (11.6.6):
+  - firebase_storage (11.6.7):
     - Firebase/Storage (= 10.20.0)
     - firebase_core
     - Flutter
@@ -198,6 +198,8 @@ PODS:
   - GTMSessionFetcher/Core (3.3.1)
   - image_picker_ios (0.0.1):
     - Flutter
+  - in_app_review (0.2.0):
+    - Flutter
   - leveldb-library (1.22.3)
   - nanopb (2.30909.1):
     - nanopb/decode (= 2.30909.1)
@@ -212,8 +214,13 @@ PODS:
   - PromisesObjC (2.3.1)
   - PromisesSwift (2.3.1):
     - PromisesObjC (= 2.3.1)
+  - rate_my_app (2.0.0):
+    - Flutter
   - ReachabilitySwift (5.0.0)
   - RecaptchaInterop (100.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sign_in_with_apple (0.0.1):
     - Flutter
   - sqflite (0.0.3):
@@ -237,8 +244,11 @@ DEPENDENCIES:
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - rate_my_app (from `.symlinks/plugins/rate_my_app/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -307,10 +317,16 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  in_app_review:
+    :path: ".symlinks/plugins/in_app_review/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  rate_my_app:
+    :path: ".symlinks/plugins/rate_my_app/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sign_in_with_apple:
     :path: ".symlinks/plugins/sign_in_with_apple/ios"
   sqflite:
@@ -326,14 +342,14 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   app_settings: 017320c6a680cdc94c799949d95b84cb69389ebc
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  cloud_firestore: ecf08badc10198974885617f14819201d9a42575
+  cloud_firestore: 0f0bca4953963272e2d8cf6f15e7adce3c10b7f7
   connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
   Firebase: 10c8cb12fb7ad2ae0c09ffc86cd9c1ab392a0031
   firebase_analytics: 2c1c3057d5da3bd3aab819f7e6ee153a4e46c59e
-  firebase_auth: 29a10d4129d53aa690c10dbd838ed1a059ef0c9b
+  firebase_auth: b237f065b2afc6bd7962124e1cbacdbef31036e6
   firebase_core: c8628c7ce80f79439149549052bff22f6784fbf5
-  firebase_crashlytics: 3054fbdd2b4a4a91f25a15e57c9f1bd2a9ed81ae
-  firebase_storage: 7ea4707a0331c7ec427a780731f5bf723a7293ea
+  firebase_crashlytics: 012078b4eec6fc9716f97ba3da0f0e44a04e95b1
+  firebase_storage: ad66b33e4e0be3e82da8a0a513c0dcc75cb08ea6
   FirebaseAnalytics: a2731bf3670747ce8f65368b118d18aa8e368246
   FirebaseAppCheckInterop: 69fc7d8f6a1cbfa973efb8d1723651de30d12525
   FirebaseAuth: 9c5c400d2c3055d8ae3a0284944c86fa95d48dac
@@ -363,14 +379,17 @@ SPEC CHECKSUMS:
   GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
   GTMSessionFetcher: 8a1b34ad97ebe6f909fb8b9b77fba99943007556
   image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425
+  in_app_review: 318597b3a06c22bb46dc454d56828c85f444f99d
   leveldb-library: e74c27d8fbd22854db7cb467968a0b8aa1db7126
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   PromisesSwift: 28dca69a9c40779916ac2d6985a0192a5cb4a265
+  rate_my_app: 80fba94c4885cd31738231b7b1f51c1ad726f5c7
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
+  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
   Toast: ec33c32b8688982cecc6348adeae667c1b9938da

--- a/lib/app/di/app_binding.dart
+++ b/lib/app/di/app_binding.dart
@@ -28,7 +28,9 @@ final class AppBinder {
 
   /// 'Splash' 단계에서 우선적으로 Binding 해야되는 모듈들은
   /// 아래 메소드에서 처리합
-  static void _initTopPriority() {}
+  static void _initTopPriority() {
+    // AppRate.init();
+  }
 
   static Future<void> init() async {
     _initTopPriority();

--- a/lib/app/di/modules/user_di.dart
+++ b/lib/app/di/modules/user_di.dart
@@ -8,8 +8,11 @@ import 'package:techtalk/features/user/data_source/local/user_local_data_source_
 import 'package:techtalk/features/user/data_source/remote/user_remote_data_source_impl.dart';
 import 'package:techtalk/features/user/repositories/user_repository_impl.dart';
 import 'package:techtalk/features/user/usecases/check_nickname_duplication.dart';
+import 'package:techtalk/features/user/usecases/disable_review_available_state_use_case.dart';
 import 'package:techtalk/features/user/usecases/edit_user_profile_use_case.dart';
+import 'package:techtalk/features/user/usecases/increase_completed_interview_count_use_case.dart';
 import 'package:techtalk/features/user/usecases/sotre_user_local_info_use_case.dart';
+import 'package:techtalk/features/user/usecases/update_last_login_date_use_cae.dart';
 import 'package:techtalk/features/user/user.dart';
 
 final class UserDependencyInjection extends FeatureDependencyInjection {
@@ -67,6 +70,15 @@ final class UserDependencyInjection extends FeatureDependencyInjection {
       )
       ..registerFactory(
         () => StoreUserLocalInfoUseCase(userRepository),
+      )
+      ..registerFactory(
+        () => UpdateLastLoginDateUseCase(userRepository),
+      )
+      ..registerFactory(
+        () => IncreaseCompletedInterviewCountUseCase(userRepository),
+      )
+      ..registerFactory(
+        () => DisableReviewAvailableStateUseCase(userRepository),
       );
   }
 }

--- a/lib/core/helper/date_time_extension.dart
+++ b/lib/core/helper/date_time_extension.dart
@@ -14,4 +14,17 @@ extension KoreaDateTimeExt on DateTime {
   bool isAfterOrSameAs(DateTime other) {
     return isAfter(other) || isAtSameMomentAs(other);
   }
+
+  ///
+  /// 주어진 datetime이 한달 이상 지났느지 확인하는 메소드
+  ///
+  bool get isOneMonthOrMorePassedFromNow {
+    DateTime now = DateTime.now();
+
+    Duration difference = now.difference(this);
+
+    double differenceInMonths = difference.inDays / 30;
+
+    return differenceInMonths >= 1;
+  }
 }

--- a/lib/features/chat/repositories/entities/chat_room_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_room_entity.dart
@@ -58,7 +58,7 @@ class ChatRoomEntity {
         throw UnimplementedError('유효하지 않은 [passOrFail]값 입니다.');
       }
     } else {
-      throw UnimplementedError('진행도가 완료되지 않았습니다.');
+      throw UnimplementedError('진행도가 완료되지 않았습니다 : $progressState');
     }
   }
 

--- a/lib/features/system/data_source/remote/system_remote_data_source_impl.dart
+++ b/lib/features/system/data_source/remote/system_remote_data_source_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -16,8 +17,8 @@ final class SystemRemoteDataSourceImpl implements SystemRemoteDataSource {
 
       return versionRef.data()!;
     } catch (e) {
-      print('아릴리릴랑이 : ${e}');
-      throw 'asdf';
+      log('버전 정보 호출 실패 : ${e}');
+      rethrow;
     }
   }
 }

--- a/lib/features/system/use_cases/set_entry_flow_use_case.dart
+++ b/lib/features/system/use_cases/set_entry_flow_use_case.dart
@@ -88,14 +88,14 @@ class SetEntryFlowUseCase extends BaseNoParamUseCase<Result<void>> {
           if (Platform.isIOS) {
             await launchUrl(
               Uri.parse(
-                'https://apps.apple.com/kr/app/%EC%88%9C%EC%82%AD/id1671820197',
+                'https://apps.apple.com/kr/app/id6478161786',
               ),
               mode: LaunchMode.externalApplication,
             );
           } else if (Platform.isAndroid) {
             await launchUrl(
               Uri.parse(
-                'https://play.google.com/store/apps/details?id=com.soon_sak',
+                'https://play.google.com/store/apps/details?id=com.techtalk',
               ),
               mode: LaunchMode.externalApplication,
             );

--- a/lib/features/user/data_source/local/boxes/user_box.dart
+++ b/lib/features/user/data_source/local/boxes/user_box.dart
@@ -7,20 +7,30 @@ class UserBox extends HiveObject {
   @HiveField(0)
   final bool hasPracticalInterviewRecord;
 
-  UserBox({required this.hasPracticalInterviewRecord});
+  @HiveField(1)
+  final bool isReviewRequestAvailable;
+
+  UserBox({
+    required this.hasPracticalInterviewRecord,
+    required this.isReviewRequestAvailable,
+  });
 
   UserBox copyWith({
     bool? hasPracticalInterviewRecord,
+    bool? isReviewRequestAvailable,
   }) {
     return UserBox(
       hasPracticalInterviewRecord:
           hasPracticalInterviewRecord ?? this.hasPracticalInterviewRecord,
+      isReviewRequestAvailable:
+          isReviewRequestAvailable ?? this.isReviewRequestAvailable,
     );
   }
 
   factory UserBox.defaultValue() {
     return UserBox(
       hasPracticalInterviewRecord: false,
+      isReviewRequestAvailable: true,
     );
   }
 }

--- a/lib/features/user/data_source/local/boxes/user_box.g.dart
+++ b/lib/features/user/data_source/local/boxes/user_box.g.dart
@@ -18,15 +18,18 @@ class UserBoxAdapter extends TypeAdapter<UserBox> {
     };
     return UserBox(
       hasPracticalInterviewRecord: fields[0] as bool,
+      isReviewRequestAvailable: fields[1] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, UserBox obj) {
     writer
-      ..writeByte(1)
+      ..writeByte(2)
       ..writeByte(0)
-      ..write(obj.hasPracticalInterviewRecord);
+      ..write(obj.hasPracticalInterviewRecord)
+      ..writeByte(1)
+      ..write(obj.isReviewRequestAvailable);
   }
 
   @override

--- a/lib/features/user/data_source/local/user_local_data_source.dart
+++ b/lib/features/user/data_source/local/user_local_data_source.dart
@@ -1,3 +1,4 @@
+import 'package:techtalk/features/user/data_source/local/boxes/user_box.dart';
 import 'package:techtalk/features/user/repositories/entities/user_entity.dart';
 
 abstract interface class UserLocalDataSource {
@@ -10,4 +11,14 @@ abstract interface class UserLocalDataSource {
   /// 유저의 로컬 정보 업데이트
   ///
   Future<void> storeUserLocalInfo(UserEntity user);
+
+  ///
+  /// 유저 로컬 데이터 로드
+  ///
+  UserBox loadUserLocalInfo();
+
+  ///
+  /// 유저 앱 평가 요청 가능 상태를 비활성화
+  ///
+  Future<void> disableReviewAvailableState();
 }

--- a/lib/features/user/data_source/local/user_local_data_source_impl.dart
+++ b/lib/features/user/data_source/local/user_local_data_source_impl.dart
@@ -19,7 +19,22 @@ final class UserLocalDataSourceImpl implements UserLocalDataSource {
   @override
   Future<void> storeUserLocalInfo(UserEntity user) async {
     final userLocalInfo = localUser?.copyWith(
-            hasPracticalInterviewRecord: user.hasPracticalInterviewRecord) ??
+          hasPracticalInterviewRecord: user.hasPracticalInterviewRecord,
+        ) ??
+        UserBox.defaultValue();
+    return box.put(AppLocal.userBoxName, userLocalInfo);
+  }
+
+  @override
+  UserBox loadUserLocalInfo() {
+    return localUser ?? UserBox.defaultValue();
+  }
+
+  @override
+  Future<void> disableReviewAvailableState() {
+    final userLocalInfo = localUser?.copyWith(
+          isReviewRequestAvailable: false,
+        ) ??
         UserBox.defaultValue();
     return box.put(AppLocal.userBoxName, userLocalInfo);
   }

--- a/lib/features/user/data_source/remote/models/user_model.dart
+++ b/lib/features/user/data_source/remote/models/user_model.dart
@@ -9,12 +9,14 @@ part 'user_model.g.dart';
 class UserModel {
   UserModel({
     required this.uid,
+    required this.signUpDate,
     this.loginCount,
     this.email,
     this.profileImgUrl,
     this.nickname,
     this.jobGroupIds,
     this.recordedTopicIds,
+    this.completedInterviewCount,
     this.techSkills,
     DateTime? lastLoginDate,
   }) : lastLoginDate = DateTime.now();
@@ -43,6 +45,13 @@ class UserModel {
   /// 접속 횟수
   final int? loginCount;
 
+  /// 완료된 면접 개수
+  final int? completedInterviewCount;
+
+  /// 가입 날짜
+  @TimeStampConverter()
+  final DateTime signUpDate;
+
   /// 마지막 로그인 시간
   @TimeStampConverter()
   final DateTime lastLoginDate;
@@ -56,6 +65,7 @@ class UserModel {
       jobGroupIds: entity.jobGroups.map((e) => e.id).toList(),
       techSkills: entity.skills.map((e) => e.id).toList(),
       email: entity.email,
+      signUpDate: entity.signUpDate,
     );
   }
 

--- a/lib/features/user/data_source/remote/models/user_model.g.dart
+++ b/lib/features/user/data_source/remote/models/user_model.g.dart
@@ -8,6 +8,9 @@ part of 'user_model.dart';
 
 UserModel _$UserModelFromJson(Map<String, dynamic> json) => UserModel(
       uid: json['uid'] as String,
+      signUpDate: const TimeStampConverter()
+          .fromJson(json['sign_up_date'] as Timestamp),
+      loginCount: json['login_count'] as int?,
       email: json['email'] as String?,
       profileImgUrl: json['profile_img_url'] as String?,
       nickname: json['nickname'] as String?,
@@ -17,6 +20,7 @@ UserModel _$UserModelFromJson(Map<String, dynamic> json) => UserModel(
       recordedTopicIds: (json['recorded_topic_ids'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      completedInterviewCount: json['completed_interview_count'] as int?,
       techSkills: (json['tech_skills'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
@@ -32,6 +36,9 @@ Map<String, dynamic> _$UserModelToJson(UserModel instance) => <String, dynamic>{
       'job_group_ids': instance.jobGroupIds,
       'tech_skills': instance.techSkills,
       'recorded_topic_ids': instance.recordedTopicIds,
+      'login_count': instance.loginCount,
+      'completed_interview_count': instance.completedInterviewCount,
+      'sign_up_date': const TimeStampConverter().toJson(instance.signUpDate),
       'last_login_date':
           const TimeStampConverter().toJson(instance.lastLoginDate),
     };

--- a/lib/features/user/data_source/remote/models/users_ref.dart
+++ b/lib/features/user/data_source/remote/models/users_ref.dart
@@ -5,6 +5,9 @@ import 'package:techtalk/features/user/data_source/remote/models/user_model.dart
 abstract class FirestoreUsersRef {
   static const String name = 'Users';
   static const String subCollectionName = 'Chats';
+  static const String lastLoginDateField = 'last_login_date';
+  static const String completedInterviewCountField =
+      'completed_interview_count';
   static String get _userUid => FirebaseAuth.instance.currentUser!.uid;
 
   static CollectionReference<UserModel> collection() =>

--- a/lib/features/user/data_source/remote/user_remote_data_source.dart
+++ b/lib/features/user/data_source/remote/user_remote_data_source.dart
@@ -25,4 +25,14 @@ abstract interface class UserRemoteDataSource {
 
   /// storage에 이미지 파일을 업로드하고 url를 리턴
   Future<String> uploadImgFileAndGetUrl(File imageFile);
+
+  ///
+  /// 마지막 접속 일자 갱신
+  ///
+  Future<void> updateLastLoginDate();
+
+  ///
+  /// 완료된 면접 개수 필드 증가 및 값 리턴
+  ///
+  Future<int> increaseCompletedInterviewCount();
 }

--- a/lib/features/user/data_source/remote/user_remote_data_source_impl.dart
+++ b/lib/features/user/data_source/remote/user_remote_data_source_impl.dart
@@ -41,7 +41,7 @@ final class UserRemoteDataSourceImpl implements UserRemoteDataSource {
     final snapshot = await FirestoreUsersRef.doc(uid).get();
 
     await FirestoreUsersRef.doc(uid).update({
-      'last_login_date': FieldValue.serverTimestamp(),
+      FirestoreUsersRef.lastLoginDateField: FieldValue.serverTimestamp(),
     });
 
     return snapshot.data()!;
@@ -89,5 +89,31 @@ final class UserRemoteDataSourceImpl implements UserRemoteDataSource {
     } else {
       throw const ImgStoreFailedException();
     }
+  }
+
+  @override
+  Future<int> increaseCompletedInterviewCount() async {
+    if (!await FirestoreUsersRef.isExist()) {
+      throw const NoUserDataException();
+    }
+
+    final snapshot = await FirestoreUsersRef.doc().get();
+
+    await FirestoreUsersRef.doc().update({
+      FirestoreUsersRef.completedInterviewCountField: FieldValue.increment(1),
+    });
+
+    return (snapshot.data()?.completedInterviewCount ?? 0) + 1;
+  }
+
+  @override
+  Future<void> updateLastLoginDate() async {
+    if (!await FirestoreUsersRef.isExist()) {
+      throw const NoUserDataException();
+    }
+
+    await FirestoreUsersRef.doc().update({
+      FirestoreUsersRef.lastLoginDateField: FieldValue.serverTimestamp(),
+    });
   }
 }

--- a/lib/features/user/repositories/entities/user_entity.dart
+++ b/lib/features/user/repositories/entities/user_entity.dart
@@ -2,6 +2,7 @@ import 'package:techtalk/core/constants/job_group.enum.dart';
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/features/tech_set/repositories/entities/skill_entity.dart';
 import 'package:techtalk/features/topic/repositories/entities/topic_entity.dart';
+import 'package:techtalk/features/user/data_source/local/boxes/user_box.dart';
 import 'package:techtalk/features/user/data_source/remote/models/user_model.dart';
 
 class UserEntity {
@@ -29,14 +30,26 @@ class UserEntity {
   /// 실전 면접 기록 존재 여부;
   final bool hasPracticalInterviewRecord;
 
+  /// 완료된 면접 개수
+  final int completedInterviewCount;
+
   /// 마지막 접속 일자
   final DateTime lastLoginDate;
+
+  /// 가입 일자
+  final DateTime signUpDate;
+
+  /// 앱 리뷰 가능 여부
+  final bool isReviewRequestAvailable;
 
   const UserEntity({
     required this.uid,
     this.profileImgUrl,
     this.nickname,
     this.email,
+    required this.signUpDate,
+    required this.completedInterviewCount,
+    required this.isReviewRequestAvailable,
     required this.hasPracticalInterviewRecord,
     required this.recordedTopics,
     required this.lastLoginDate,
@@ -44,9 +57,11 @@ class UserEntity {
     required this.skills,
   });
 
-  factory UserEntity.fromModel(UserModel model,
-      {required List<SkillEntity> skills,
-      required bool hasPracticalInterviewRecord}) {
+  factory UserEntity.fromModel(
+    UserModel model, {
+    required List<SkillEntity> skills,
+    required UserBox box,
+  }) {
     return UserEntity(
       uid: model.uid,
       nickname: model.nickname,
@@ -57,40 +72,46 @@ class UserEntity {
       recordedTopics: model.recordedTopicIds != null
           ? model.recordedTopicIds!.map(StoredTopics.getById).toList()
           : [],
-      hasPracticalInterviewRecord: hasPracticalInterviewRecord,
+      hasPracticalInterviewRecord: box.hasPracticalInterviewRecord,
       skills: skills,
       lastLoginDate: model.lastLoginDate,
       email: model.email,
+      completedInterviewCount: model.completedInterviewCount ?? 0,
+      isReviewRequestAvailable: box.isReviewRequestAvailable,
+      signUpDate: model.signUpDate,
     );
-  }
-
-  @override
-  String toString() {
-    return 'UserEntity{uid: $uid, profileImgUrl: $profileImgUrl, nickname: $nickname, jobGroups: $jobGroups, skills: $skills, lastLoginDate: $lastLoginDate}';
   }
 
   UserEntity copyWith({
     String? uid,
     String? profileImgUrl,
     String? nickname,
-    List<JobGroup>? jobGroups,
-    List<TopicEntity>? recordedTopicIds,
-    List<SkillEntity>? skills,
-    DateTime? lastLoginDate,
     String? email,
+    List<JobGroup>? jobGroups,
+    List<SkillEntity>? skills,
+    List<TopicEntity>? recordedTopics,
     bool? hasPracticalInterviewRecord,
+    int? completedInterviewCount,
+    DateTime? lastLoginDate,
+    DateTime? signUpDate,
+    bool? isReviewRequestAvailable,
   }) {
     return UserEntity(
-      email: email ?? this.email,
       uid: uid ?? this.uid,
       profileImgUrl: profileImgUrl ?? this.profileImgUrl,
       nickname: nickname ?? this.nickname,
-      recordedTopics: recordedTopicIds ?? this.recordedTopics,
+      email: email ?? this.email,
       jobGroups: jobGroups ?? this.jobGroups,
       skills: skills ?? this.skills,
+      recordedTopics: recordedTopics ?? this.recordedTopics,
       hasPracticalInterviewRecord:
           hasPracticalInterviewRecord ?? this.hasPracticalInterviewRecord,
+      completedInterviewCount:
+          completedInterviewCount ?? this.completedInterviewCount,
       lastLoginDate: lastLoginDate ?? this.lastLoginDate,
+      signUpDate: signUpDate ?? this.signUpDate,
+      isReviewRequestAvailable:
+          isReviewRequestAvailable ?? this.isReviewRequestAvailable,
     );
   }
 }

--- a/lib/features/user/repositories/user_repository.dart
+++ b/lib/features/user/repositories/user_repository.dart
@@ -17,4 +17,19 @@ abstract interface class UserRepository {
 
   /// 면접 기록 존재 여부 필드 값 업데이트
   Future<Result<void>> storeUserLocalInfo(UserEntity user);
+
+  ///
+  /// 마지막 접속 일자 갱신
+  ///
+  Future<Result<void>> updateLastLoginDate();
+
+  ///
+  /// 완료된 면접 개수 필드 증가 및 값 리턴
+  ///
+  Future<Result<int>> increaseCompletedInterviewCount();
+
+  ///
+  /// 유저 앱 평가 요청 가능 상태를 비활성화
+  ///
+  Future<Result<void>> disableReviewAvailableState();
 }

--- a/lib/features/user/repositories/user_repository_impl.dart
+++ b/lib/features/user/repositories/user_repository_impl.dart
@@ -34,17 +34,17 @@ final class UserRepositoryImpl implements UserRepository {
   @override
   Future<Result<UserEntity>> getUser([String? uid]) async {
     try {
-      final response = await _userRemoteDataSource.getUser();
-      final List<SkillEntity> skills = response.techSkills != null
-          ? response.techSkills!.map(_techSetRepository.getSkillById).toList()
+      final remoteRes = await _userRemoteDataSource.getUser();
+      final localRes = _userLocalDataSource.loadUserLocalInfo();
+      final List<SkillEntity> skills = remoteRes.techSkills != null
+          ? remoteRes.techSkills!.map(_techSetRepository.getSkillById).toList()
           : [];
 
-      final hasPracticalInterviewRecord =
-          _userLocalDataSource.hasPracticalInterviewRecord();
-
-      final result = UserEntity.fromModel(response,
-          skills: skills,
-          hasPracticalInterviewRecord: hasPracticalInterviewRecord);
+      final result = UserEntity.fromModel(
+        remoteRes,
+        skills: skills,
+        box: localRes,
+      );
 
       return Result.success(result);
     } on Exception catch (e) {
@@ -102,6 +102,37 @@ final class UserRepositoryImpl implements UserRepository {
   Future<Result<void>> storeUserLocalInfo(UserEntity user) async {
     try {
       final response = await _userLocalDataSource.storeUserLocalInfo(user);
+      return Result.success(response);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  @override
+  Future<Result<int>> increaseCompletedInterviewCount() async {
+    try {
+      final response =
+          await _userRemoteDataSource.increaseCompletedInterviewCount();
+      return Result.success(response);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  @override
+  Future<Result<void>> updateLastLoginDate() async {
+    try {
+      final response = await _userRemoteDataSource.updateLastLoginDate();
+      return Result.success(response);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  @override
+  Future<Result<void>> disableReviewAvailableState() async {
+    try {
+      final response = await _userLocalDataSource.disableReviewAvailableState();
       return Result.success(response);
     } on Exception catch (e) {
       return Result.failure(e);

--- a/lib/features/user/usecases/disable_review_available_state_use_case.dart
+++ b/lib/features/user/usecases/disable_review_available_state_use_case.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:techtalk/core/core.dart';
+import 'package:techtalk/core/utils/base/base_no_param_use_case.dart';
+import 'package:techtalk/features/user/repositories/user_repository.dart';
+
+class DisableReviewAvailableStateUseCase
+    extends BaseNoParamUseCase<Result<void>> {
+  DisableReviewAvailableStateUseCase(this._repository);
+
+  final UserRepository _repository;
+
+  @override
+  FutureOr<Result<void>> call() async =>
+      _repository.disableReviewAvailableState();
+}

--- a/lib/features/user/usecases/increase_completed_interview_count_use_case.dart
+++ b/lib/features/user/usecases/increase_completed_interview_count_use_case.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:techtalk/core/core.dart';
+import 'package:techtalk/core/utils/base/base_no_param_use_case.dart';
+import 'package:techtalk/features/user/repositories/user_repository.dart';
+
+final class IncreaseCompletedInterviewCountUseCase
+    extends BaseNoParamUseCase<Result<int>> {
+  IncreaseCompletedInterviewCountUseCase(this._repository);
+
+  final UserRepository _repository;
+
+  @override
+  FutureOr<Result<int>> call() async =>
+      _repository.increaseCompletedInterviewCount();
+}

--- a/lib/features/user/usecases/update_last_login_date_use_cae.dart
+++ b/lib/features/user/usecases/update_last_login_date_use_cae.dart
@@ -1,0 +1,14 @@
+import 'dart:async';
+
+import 'package:techtalk/core/core.dart';
+import 'package:techtalk/core/utils/base/base_no_param_use_case.dart';
+import 'package:techtalk/features/user/repositories/user_repository.dart';
+
+class UpdateLastLoginDateUseCase extends BaseNoParamUseCase<Result<void>> {
+  UpdateLastLoginDateUseCase(this._repository);
+
+  final UserRepository _repository;
+
+  @override
+  FutureOr<Result<void>> call() async => _repository.updateLastLoginDate();
+}

--- a/lib/features/user/user.dart
+++ b/lib/features/user/user.dart
@@ -4,10 +4,13 @@ import 'package:techtalk/features/user/data_source/remote/user_remote_data_sourc
 import 'package:techtalk/features/user/repositories/user_repository.dart';
 import 'package:techtalk/features/user/usecases/check_nickname_duplication.dart';
 import 'package:techtalk/features/user/usecases/create_user_use_case.dart';
+import 'package:techtalk/features/user/usecases/disable_review_available_state_use_case.dart';
 import 'package:techtalk/features/user/usecases/edit_user_profile_use_case.dart';
 import 'package:techtalk/features/user/usecases/get_user_use_case.dart';
+import 'package:techtalk/features/user/usecases/increase_completed_interview_count_use_case.dart';
 import 'package:techtalk/features/user/usecases/resign_user_info_use_case.dart';
 import 'package:techtalk/features/user/usecases/sotre_user_local_info_use_case.dart';
+import 'package:techtalk/features/user/usecases/update_last_login_date_use_cae.dart';
 import 'package:techtalk/features/user/usecases/update_user_use_case.dart';
 
 export 'data_source/remote/user_remote_data_source.dart';
@@ -28,3 +31,8 @@ final updateUserUseCase = locator<UpdateUserUseCase>();
 final getUserUseCase = locator<GetUserUseCase>();
 final resignUserInfoUseCase = locator<ResignUserInfoUseCase>();
 final storeUserLocalInfo = locator<StoreUserLocalInfoUseCase>();
+final updateLastLoginDateUseCase = locator<UpdateLastLoginDateUseCase>();
+final increaseCompletedInterviewCountUseCase =
+    locator<IncreaseCompletedInterviewCountUseCase>();
+final disableReviewAvailableStateUseCase =
+    locator<DisableReviewAvailableStateUseCase>();

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -56,12 +56,6 @@ class HomePage extends BasePage with HomeState {
   bool get canPop => false;
 
   @override
-  void onWillPop(WidgetRef ref) {
-    super.onWillPop(ref);
-    print('아지랑이랑');
-  }
-
-  @override
   Color? get screenBackgroundColor => AppColor.of.background1;
 
   @override

--- a/lib/presentation/pages/interview/chat/chat_event.dart
+++ b/lib/presentation/pages/interview/chat/chat_event.dart
@@ -9,6 +9,7 @@ import 'package:techtalk/core/services/snack_bar_service.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/enums/interview_progress.enum.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/chat_message_history_provider.dart';
+import 'package:techtalk/presentation/pages/interview/chat/providers/chat_scroll_controller.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart';
 import 'package:techtalk/presentation/widgets/common/dialog/app_dialog.dart';
 
@@ -24,6 +25,14 @@ mixin class ChatEvent {
     WidgetRef ref, {
     required TextEditingController textEditingController,
   }) async {
+    unawaited(
+      ref.read(chatScrollControllerProvider).animateTo(
+            0,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          ),
+    );
+
     final message = textEditingController.text;
     if (message.isEmpty) {
       unawaited(HapticFeedback.vibrate());
@@ -105,7 +114,7 @@ mixin class ChatEvent {
                 ref.context.pop();
                 ScaffoldMessenger.of(ref.context).showSnackBar(
                   const SnackBar(
-                    content: Text('신고해주셔서 감사합니다.'),
+                    content: Text('피드백 주셔서 감사합니다.'),
                   ),
                 );
               },

--- a/lib/presentation/pages/interview/chat/chat_state.dart
+++ b/lib/presentation/pages/interview/chat/chat_state.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/entities/interviewer_entity.dart';
@@ -5,6 +6,7 @@ import 'package:techtalk/features/chat/repositories/enums/interview_progress.enu
 import 'package:techtalk/presentation/pages/interview/chat/providers/chat_async_adapter_provider.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/chat_message_history_provider.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/chat_qnas_provider.dart';
+import 'package:techtalk/presentation/pages/interview/chat/providers/chat_scroll_controller.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/interview_progress_state_provider.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart';
 
@@ -55,4 +57,10 @@ mixin class ChatState {
               ),
             ],
           );
+
+  ///
+  /// 채팅 스크롤 컨트롤러
+  ///
+  ScrollController chatScrollController(WidgetRef ref) =>
+      ref.watch(chatScrollControllerProvider);
 }

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
@@ -3,12 +3,14 @@ import 'dart:developer';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/services.dart';
+import 'package:in_app_review/in_app_review.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/core/helper/list_extension.dart';
 import 'package:techtalk/core/helper/string_extension.dart';
 import 'package:techtalk/core/services/snack_bar_service.dart';
 import 'package:techtalk/features/chat/chat.dart';
+import 'package:techtalk/features/user/user.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/chat_qnas_provider.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart';
 import 'package:techtalk/presentation/providers/user/user_info_provider.dart';
@@ -179,7 +181,7 @@ class ChatMessageHistory extends _$ChatMessageHistory {
                         message: nextQuestionChat.overwriteToStream());
                   }
                 },
-              )
+              ),
             ],
           );
         },

--- a/lib/presentation/pages/interview/chat/providers/chat_scroll_controller.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_scroll_controller.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/cupertino.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'chat_scroll_controller.g.dart';
+
+@riverpod
+Raw<ScrollController> chatScrollController(ChatScrollControllerRef ref) {
+  return ScrollController();
+}

--- a/lib/presentation/pages/interview/chat/providers/chat_scroll_controller.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_scroll_controller.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_scroll_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$chatScrollControllerHash() =>
+    r'6d163f3a889cd93e1f0f3a1abf25518c1c33848c';
+
+/// See also [chatScrollController].
+@ProviderFor(chatScrollController)
+final chatScrollControllerProvider =
+    AutoDisposeProvider<Raw<ScrollController>>.internal(
+  chatScrollController,
+  name: r'chatScrollControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$chatScrollControllerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ChatScrollControllerRef = AutoDisposeProviderRef<Raw<ScrollController>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.g.dart
@@ -7,7 +7,7 @@ part of 'interview_progress_state_provider.dart';
 // **************************************************************************
 
 String _$interviewProgressStateHash() =>
-    r'b9239b12ab3cba5afb78c527f4939481e2c7b106';
+    r'46614baf13bfb98b340630817feb5744b0aa8c5d';
 
 /// See also [InterviewProgressState].
 @ProviderFor(InterviewProgressState)

--- a/lib/presentation/pages/interview/chat/widgets/bubble.dart
+++ b/lib/presentation/pages/interview/chat/widgets/bubble.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/core/constants/assets.dart';
 import 'package:techtalk/core/theme/extension/app_color.dart';
 import 'package:techtalk/core/theme/extension/app_text_style.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/entities/interviewer_entity.dart';
 import 'package:techtalk/presentation/widgets/common/avatar/clip_oval_circle_avatar.dart';
+import 'package:techtalk/presentation/widgets/common/button/icon_flash_area_button.dart';
 import 'package:techtalk/presentation/widgets/common/common.dart';
 
 class Bubble extends StatelessWidget {
@@ -122,6 +124,30 @@ class Bubble extends StatelessWidget {
                 },
               ),
             ),
+            if (item is FeedbackChatMessageEntity && item.message.isClosed)
+              Row(
+                children: [
+                  const Gap(5),
+                  Container(
+                    padding: const EdgeInsets.all(3),
+                    decoration: BoxDecoration(
+                      color: AppColor.of.red1,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Consumer(
+                      builder: (context, ref, child) {
+                        return IconFlashAreaButton.assetIcon(
+                          iconPath: Assets.iconsWarning,
+                          size: 10,
+                          onIconTapped: onReportBtnTapped,
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              )
+            else
+              EmptyBox(),
           ],
         ),
       );

--- a/lib/presentation/pages/interview/chat/widgets/interview_tab_view.dart
+++ b/lib/presentation/pages/interview/chat/widgets/interview_tab_view.dart
@@ -19,8 +19,6 @@ class InterviewTabView extends HookConsumerWidget with ChatState, ChatEvent {
   Widget build(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
 
-    final chatScrollController = useScrollController();
-
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -34,7 +32,7 @@ class InterviewTabView extends HookConsumerWidget with ChatState, ChatEvent {
                     return Align(
                       alignment: Alignment.topCenter,
                       child: ListView.separated(
-                          controller: chatScrollController,
+                          controller: chatScrollController(ref),
                           shrinkWrap: true,
                           reverse: true,
                           padding: const EdgeInsets.only(top: 24, bottom: 20) +

--- a/lib/presentation/pages/main/main_event.dart
+++ b/lib/presentation/pages/main/main_event.dart
@@ -1,5 +1,13 @@
+import 'dart:async';
+import 'dart:developer';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:techtalk/core/helper/date_time_extension.dart';
+import 'package:techtalk/features/user/user.dart';
 import 'package:techtalk/presentation/providers/main_bottom_navigation_provider.dart';
+import 'package:techtalk/presentation/providers/system/detect_network_connectivity_provider.dart';
+import 'package:techtalk/presentation/providers/user/user_info_provider.dart';
 
 mixin class MainEvent {
   void onTapBottomNavigationItem(
@@ -8,5 +16,36 @@ mixin class MainEvent {
   }) {
     ref.read(mainBottomNavigationProvider.notifier).tab =
         MainNavigationTab.values[index];
+  }
+
+  ///
+  /// 네트워크 변화 실시간 탐지 모듈 실행
+  ///
+  void activateNetworkConnectivityDetector(WidgetRef ref) {
+    ref.read(detectNetworkConnectivityProvider);
+  }
+
+  ///
+  /// 조건별로 앱 평가 다이어로그 노출
+  ///
+  Future<void> alertRateAppDialogIfNeeded(WidgetRef ref) async {
+    final user = ref.read(userInfoProvider).requireValue!;
+
+    if (user.signUpDate.isOneMonthOrMorePassedFromNow &&
+        user.isReviewRequestAvailable) {
+      final InAppReview inAppReview = InAppReview.instance;
+      if (await inAppReview.isAvailable()) {
+        unawaited(inAppReview.requestReview());
+        final response = await disableReviewAvailableStateUseCase.call();
+        response.fold(
+          onSuccess: (_) {
+            log('앱 평가 다이어로그 노출 가능 상태 비활성화');
+          },
+          onFailure: (e) {
+            log('앱 평가 다이어로그 노출 가능 상태 변화 실패 : ${e}');
+          },
+        );
+      }
+    }
   }
 }

--- a/lib/presentation/pages/main/main_page.dart
+++ b/lib/presentation/pages/main/main_page.dart
@@ -13,10 +13,9 @@ import 'package:techtalk/presentation/pages/my_info/my_page/my_page.dart';
 import 'package:techtalk/presentation/pages/study/topic_selection/study_topic_selection_page.dart';
 import 'package:techtalk/presentation/pages/wrong_answer_note/wrong_answer_note_page.dart';
 import 'package:techtalk/presentation/providers/main_bottom_navigation_provider.dart';
-import 'package:techtalk/presentation/providers/system/detect_network_connectivity_provider.dart';
 import 'package:techtalk/presentation/widgets/base/base_page.dart';
 
-class MainPage extends BasePage {
+class MainPage extends BasePage with MainEvent {
   const MainPage({super.key});
 
   @override
@@ -61,8 +60,10 @@ class MainPage extends BasePage {
   @override
   void onInit(WidgetRef ref) {
     super.onInit(ref);
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(detectNetworkConnectivityProvider);
+      activateNetworkConnectivityDetector(ref);
+      alertRateAppDialogIfNeeded(ref);
     });
   }
 

--- a/lib/presentation/pages/my_info/my_page/my_page_event.dart
+++ b/lib/presentation/pages/my_info/my_page/my_page_event.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:in_app_review/in_app_review.dart';
 import 'package:techtalk/app/module/app_local.dart';
 import 'package:techtalk/app/router/router.dart';
 import 'package:techtalk/core/constants/profile_setting_type.enum.dart';
@@ -38,6 +39,14 @@ mixin class MyPageEvent {
       Uri.parse('http://pf.kakao.com/_YWxoaG/chat'),
       mode: LaunchMode.externalApplication,
     );
+  }
+
+  ///
+  /// 앱 평가하기. 스토어 페이지로 이동
+  ///
+  Future<void> onRateAppTapped() async {
+    final InAppReview inAppReview = InAppReview.instance;
+    await inAppReview.openStoreListing(appStoreId: '6478161786');
   }
 
   ///

--- a/lib/presentation/pages/my_info/my_page/widgets/setting_card.dart
+++ b/lib/presentation/pages/my_info/my_page/widgets/setting_card.dart
@@ -36,6 +36,7 @@ class _SettingCard extends ConsumerWidget with MyPageState, MyPageEvent {
                   onTap: onVisitCsPageTapped, text: '피드백 및 문의사항'),
               CardListTileButton(
                   onTap: onVisitPolicyPageBtnTapped, text: '개인정보 및 약관'),
+              CardListTileButton(onTap: onRateAppTapped, text: '앱 평가하기'),
             ],
           ),
         ),

--- a/lib/presentation/pages/sign_up/events/sign_up_event.dart
+++ b/lib/presentation/pages/sign_up/events/sign_up_event.dart
@@ -49,9 +49,10 @@ mixin class SignUpEvent {
         recordedTopics: [],
         hasPracticalInterviewRecord: false,
         email: ref.read(userAuthProvider)?.email,
+        completedInterviewCount: 0,
+        isReviewRequestAvailable: true,
+        signUpDate: DateTime.now(),
       );
-
-      print('아무튼 : ${userData.nickname}');
 
       await ref.read(userInfoProvider.notifier).createData(userData).then(
         (_) {

--- a/lib/presentation/providers/user/user_info_provider.dart
+++ b/lib/presentation/providers/user/user_info_provider.dart
@@ -73,7 +73,7 @@ class UserInfo extends _$UserInfo {
 
     if (!updatedTopicRecords.isElementEquals(currentRecords)) {
       final updatedUserInfo =
-          state.requireValue!.copyWith(recordedTopicIds: updatedTopicRecords);
+          state.requireValue!.copyWith(recordedTopics: updatedTopicRecords);
 
       final response = await updateUserUseCase(updatedUserInfo);
       response.fold(

--- a/lib/presentation/providers/user/user_info_provider.g.dart
+++ b/lib/presentation/providers/user/user_info_provider.g.dart
@@ -6,7 +6,7 @@ part of 'user_info_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userInfoHash() => r'603f2e4af065bf713b42f159419bbf852697a23e';
+String _$userInfoHash() => r'baf4e6f77c272b20088e7eb657db2af78a3da4b4';
 
 /// See also [UserInfo].
 @ProviderFor(UserInfo)

--- a/lib/presentation/widgets/base/base_page.dart
+++ b/lib/presentation/widgets/base/base_page.dart
@@ -13,10 +13,13 @@ abstract class BasePage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     /// 페이지의 초기화 및 해제를 처리
-    useEffect(() {
-      onInit(ref);
-      return () => onDispose(ref);
-    });
+    useEffect(
+      () {
+        onInit(ref);
+        return () => onDispose(ref);
+      },
+      [],
+    );
 
     /// 앱의 라이플 사이클 변화를 처리
     useOnAppLifecycleStateChange((previousState, state) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -237,26 +237,26 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: e51b896f23f96c541c29171ccfbe771696cc280767d1412df1237db4effea285
+      sha256: "6f6a9e7f1c68f34ffe159c911a290fa7caf1a09b8a88aa1534c65f0246953970"
       url: "https://pub.dev"
     source: hosted
-    version: "4.15.5"
+    version: "4.15.6"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "8c5834277519f7e68d4bdf5ae04046ede3cb98ce7e3cfced3153fb83a16d2508"
+      sha256: "4e92549af19f0d2eec7e379ca44f909caef8eb52295a0cde5467b018cfae0378"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.6"
+    version: "6.1.7"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: "4f5d9164cf9873d05573eddeec62210be0efa5e4cb047ea81253b6da25ebd9dc"
+      sha256: "2b34cff977da11a4822151d967c5e6ce62640cbcb56d6e52a46382d2316350ac"
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.5"
+    version: "3.10.6"
   code_builder:
     dependency: transitive
     description:
@@ -381,10 +381,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.6"
   dbus:
     dependency: transitive
     description:
@@ -429,10 +429,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -501,26 +501,26 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: "549f8ceb8cfc1920f85dea0ab73fb7dc209ee8182916b252eda342786c33369d"
+      sha256: "6d8b4455524e2a619a135169a0ae817778d4acf56172188acae85f69f5e67185"
       url: "https://pub.dev"
     source: hosted
-    version: "4.17.4"
+    version: "4.17.6"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: dba259dee045b706112c3d7619b01c2ad338d86cc492df52dd2073584a64de66
+      sha256: "3eed984830f610f43164d539ec6228820cf4936ab6ef491e1afcfaca80143c84"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.5"
+    version: "7.1.6"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: d2266452698dd5f6e522408dacfa06bb7f9703b5bdd11498fce2812ded50805b
+      sha256: fcf4718abc722131218de3b84772d83019be48c9211dbd5998aece716c52ff31
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.4"
+    version: "5.9.6"
   firebase_core:
     dependency: "direct main"
     description:
@@ -549,42 +549,42 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: "4c754db28a7daabe03c4cbf1079dbe81e6f0681284fed6d07e0e640b7f1027c4"
+      sha256: "0126fa101b74fb981796b3e6f47ccf7fc40237ec918327aaec7c0a06fd1bb4c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.15"
+    version: "3.4.16"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: "08c5d7b5f93dbad7306d26702935abd8b579313ea256eb27006562a1867df249"
+      sha256: cdfa0a20d66e1b32de542883c0ddf651ee9b66b12cebf73067e4d2cdc0865d17
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.22"
+    version: "3.6.23"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
-      sha256: a07433d3ffe948f7a10086e4b0bd3a940be4ed873cffd24746eed1896b568369
+      sha256: "261763ebb2722abb8d3c702f467a9efb1f4ac8978a94c03850b80cfa3009c400"
       url: "https://pub.dev"
     source: hosted
-    version: "11.6.6"
+    version: "11.6.7"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
-      sha256: af99d9fcf058d6f3a591cea899cad054ded7adb21fb1788dfe65c3e223196b15
+      sha256: "41e5832d930f668a62aa4fd3dc9778af3a301297170f549b882dad4c5b7d3bc7"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.9"
+    version: "5.1.10"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
-      sha256: "06a684016de9609928865798dece0f7d34782a15a76f5ac08bd3a8780035b0b2"
+      sha256: "5eac3e415e01384e8a5fc92510db61fee3001d7008fa0209ff2290bcd051b6c7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.7.1"
   fixnum:
     dependency: transitive
     description:
@@ -828,10 +828,10 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_web
-      sha256: a278ea2d01013faf341cbb093da880d0f2a552bbd1cb6ee90b5bebac9ba69d77
+      sha256: f2b3af0ba52ff59439f18962fca71db860f09507a81da929fc0e719270b35db2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.3+2"
+    version: "0.12.3+3"
   graphs:
     dependency: transitive
     description:
@@ -972,10 +972,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: fa4e815e6fcada50e35718727d83ba1c92f1edf95c0b4436554cec301b56233b
+      sha256: "3d2c323daea9d60608f1caf30be32a938916f4975434b8352e6f73dae496da38"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.3"
+    version: "2.9.4"
   image_picker_windows:
     dependency: transitive
     description:
@@ -984,6 +984,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  in_app_review:
+    dependency: "direct main"
+    description:
+      name: in_app_review
+      sha256: "41ec6f30427ab09eb6ae1c85c4a2a624a145fc5d726f023de4d97170ec9e5466"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
+  in_app_review_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_review_platform_interface
+      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   intl:
     dependency: "direct main"
     description:
@@ -1284,10 +1300,10 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: "9a96a0a19b594dbc5bf0f1f27d2bc67d5f95957359b461cd9feb44ed6ae75096"
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.2"
   pub_semver:
     dependency: "direct main"
     description:
@@ -1745,18 +1761,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "939ab60734a4f8fa95feacb55804fa278de28bdeef38e616dc08e44a84adea23"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -1798,5 +1814,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.3 <4.0.0"
-  flutter: ">=3.16.6"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,8 @@ dependencies:
   app_settings: ^5.1.1 # Device Setting Route
   korean_profanity_filter: ^1.0.0 # 비속어 욕설 필터링
   icons_launcher: ^2.1.7 # 앱 아이콘
+  in_app_review: ^2.0.8 # 인앱 리뷰
+
 
   # 앱 정보
   package_info_plus: ^5.0.1 # 현재 앱 버전 정보


### PR DESCRIPTION
## 📝 변경 내용
- 면접이 2, 12 번째 완료 되었을 유저에게 앱 리뷰를 요청.
- 한달이 지난 시점에서 앱을 로드시 유저엑 앱 리뷰를 요청. 이후 로컬에 조건 값을 저장하여 더 이상 리뷰를 요청하지 않도록 함.
- 마이페이지에 스토어 페이지로 이동하여 리뷰를 할 수 있는 ListTile UI 및 기능 추가
- 앱 업데이트 모달에서 스토어 페이지로 이동할 수 있게 스토어 링크 데이터를 추가.
- 채팅 말풍선 UI 개선 및 인터렉션 로직 고도화

<br>

## 🔍 변경 이유
https://github.com/MakeFrog/TechTalk/issues/97,

<br>

## 🌍 주요 변경점
* 유저 로컬, 원격 관련 엔티티 모델 필드값 추가 (최초 가입 일자, 앱 권유 모달 노출 가능 여부 등)
<br>

## 📌 기타 사항
* 없음

