### PR TITLE
Feat: [채팅] 채팅면접 답변에 대해 일부 json으로 변경, 및 일부 프롬프트 수정

### DIFF
--- a/lib/app/di/modules/chat_di.dart
+++ b/lib/app/di/modules/chat_di.dart
@@ -1,21 +1,22 @@
 import 'package:techtalk/app/di/app_binding.dart';
 import 'package:techtalk/app/di/feature_di_interface.dart';
 import 'package:techtalk/features/chat/chat.dart';
-
-import 'package:techtalk/features/chat/use_cases/set_gemini_ai_feedback_use_case.dart';
+import 'package:techtalk/features/chat/use_cases/set_ai_feedback_use_case.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
 final class ChatDependencyInject extends FeatureDependencyInjection {
   @override
   void dataSources() {
     locator.registerLazySingleton<ChatRemoteDataSource>(
-        () => ChatRemoteDataSourceImpl());
+      () => ChatRemoteDataSourceImpl(),
+    );
   }
 
   @override
   void repositories() {
     locator.registerLazySingleton<ChatRepository>(
-        () => ChatRepositoryImpl(chatRemoteDataSource));
+      () => ChatRepositoryImpl(chatRemoteDataSource),
+    );
   }
 
   @override
@@ -42,7 +43,7 @@ final class ChatDependencyInject extends FeatureDependencyInjection {
         ),
       )
       ..registerFactory(
-        () => SetGeminiAiFeedbackUseCase(),
+        () => SetAiFeedbackUseCase(),
       )
       ..registerFactory(
         () => CreateChatMessagesUseCase(

--- a/lib/app/environment/flavor.dart
+++ b/lib/app/environment/flavor.dart
@@ -1,3 +1,4 @@
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -40,13 +41,18 @@ class Flavor {
       options: option,
     );
 
+    OpenAI.instance.build(
+      token: env.openApiKey,
+      baseOption: HttpSetup(receiveTimeout: const Duration(seconds: 10), connectTimeout: const Duration(seconds: 10)),
+      enableLog: true,
+    );
+
     /// 앱 DI 실행
     await AppBinder.init();
 
     await EasyLocalization.ensureInitialized();
 
-    await FirebaseAnalytics.instance
-        .setAnalyticsCollectionEnabled(_env == Environment.prod ? true : false);
+    await FirebaseAnalytics.instance.setAnalyticsCollectionEnabled(_env == Environment.prod ? true : false);
     if (_env == Environment.prod) {
       await FirebaseAnalytics.instance.logAppOpen();
     }

--- a/lib/features/chat/chat.dart
+++ b/lib/features/chat/chat.dart
@@ -8,7 +8,7 @@ import 'package:techtalk/features/chat/use_cases/get_chat_qnas_use_case.dart';
 import 'package:techtalk/features/chat/use_cases/get_chat_rooms_use_case.dart';
 import 'package:techtalk/features/chat/use_cases/get_random_qnas_use_case.dart';
 import 'package:techtalk/features/chat/use_cases/report_chat_use_case.dart';
-import 'package:techtalk/features/chat/use_cases/set_gemini_ai_feedback_use_case.dart';
+import 'package:techtalk/features/chat/use_cases/set_ai_feedback_use_case.dart';
 
 export 'chat.dart';
 export 'data_source/remote/chat_ref.dart';
@@ -43,12 +43,11 @@ export 'use_cases/get_chat_qnas_use_case.dart';
 export 'use_cases/get_chat_rooms_use_case.dart';
 export 'use_cases/get_random_qnas_use_case.dart';
 export 'use_cases/report_chat_use_case.dart';
-export 'use_cases/set_ai_feedback_use_case.dart';
 
 final chatRemoteDataSource = locator<ChatRemoteDataSource>();
 final chatRepository = locator<ChatRepository>();
 final getChatMessageHistoryUseCase = locator<GetChatMessageHistoryUseCase>();
-final getAnswerFeedBackUseCase = locator<SetGeminiAiFeedbackUseCase>();
+final getAnswerFeedBackUseCase = locator<SetAiFeedbackUseCase>();
 final createChatMessagesUseCase = locator<CreateChatMessagesUseCase>();
 final createChatRoomUseCase = locator<CreateChatRoomUseCase>();
 final getChatRoomsUseCase = locator<GetChatRoomsUseCase>();

--- a/lib/features/chat/repositories/entities/chat_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_qna_entity.dart
@@ -4,24 +4,27 @@ import 'package:techtalk/features/topic/topic.dart';
 class ChatQnaEntity {
   final QnaEntity qna; // 문답
   final AnswerChatEntity? message; // 유저 응답
+  final List<ChatQnaEntity>? followUpQuestions; // 꼬리질문들
 
   bool get hasUserResponded => message != null;
 
   ChatQnaEntity({
     required this.qna,
     this.message,
+    this.followUpQuestions,
   });
 
-  factory ChatQnaEntity.fromQnaEntity(QnaEntity entity) =>
-      ChatQnaEntity(qna: entity);
+  factory ChatQnaEntity.fromQnaEntity(QnaEntity entity) => ChatQnaEntity(qna: entity);
 
   ChatQnaEntity copyWith({
     QnaEntity? qna,
     AnswerChatEntity? message,
+    List<ChatQnaEntity>? followUpQuestions,
   }) {
     return ChatQnaEntity(
       qna: qna ?? this.qna,
       message: message ?? this.message,
+      followUpQuestions: followUpQuestions ?? this.followUpQuestions,
     );
   }
 }

--- a/lib/features/chat/repositories/entities/feedback_response_entity.dart
+++ b/lib/features/chat/repositories/entities/feedback_response_entity.dart
@@ -1,0 +1,33 @@
+import 'package:techtalk/features/chat/chat.dart';
+
+class FeedbackResponseEntity {
+  final String feedback; // 면접자의 답변에 대한 피드백
+  final int score; // 면접자의 답변에 대한 점수
+  final bool isFollowUpQuestionNeeded; // 꼬리질문 필요 여부
+  final ChatQnaEntity topicQuestion; // 메인 토픽 질문
+
+  FeedbackResponseEntity(
+      {required this.feedback,
+      required this.score,
+      required this.isFollowUpQuestionNeeded,
+      required this.topicQuestion});
+
+  factory FeedbackResponseEntity.fromJson(Map<String, dynamic> json, String feedback, ChatQnaEntity topicQuestion) {
+    return FeedbackResponseEntity(
+      feedback: feedback,
+      score: json['score'],
+      isFollowUpQuestionNeeded: json['isFollowUpQuestionNeeded'],
+      topicQuestion: topicQuestion,
+    );
+  }
+
+  FeedbackResponseEntity copyWith(
+      {String? feedback, int? score, bool? isFollowUpQuestionNeeded, ChatQnaEntity? topicQuestion}) {
+    return FeedbackResponseEntity(
+      feedback: feedback ?? this.feedback,
+      score: score ?? this.score,
+      isFollowUpQuestionNeeded: isFollowUpQuestionNeeded ?? this.isFollowUpQuestionNeeded,
+      topicQuestion: topicQuestion ?? this.topicQuestion,
+    );
+  }
+}

--- a/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
@@ -1,157 +1,233 @@
-// import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
-// import 'package:easy_localization/easy_localization.dart';
-// import 'package:firebase_auth/firebase_auth.dart';
-// import 'package:flutter/services.dart';
-// import 'package:rxdart/rxdart.dart';
-// import 'package:techtalk/app/localization/locale_keys.g.dart';
-// import 'package:techtalk/core/index.dart';
-// import 'package:techtalk/features/chat/chat.dart';
+import 'dart:convert';
 
-// class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
-//     Result<BehaviorSubject<String>>> {
-//   ///
-//   /// 피드백 진행 상태
-//   ///
-//   FeedbackProgress state = FeedbackProgress.init;
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/services.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:techtalk/app/localization/app_locale.dart';
+import 'package:techtalk/core/index.dart';
+import 'package:techtalk/features/chat/chat.dart';
 
-//   ///
-//   /// 면접 질문에 대한 유저의 응답의 정답여부를 확인
-//   /// propmt 로직을 고도화 할 필요 있음.
-//   ///
-//   @override
-//   Result<BehaviorSubject<String>> call(GetQuestionFeedbackParam param) {
-//     final BehaviorSubject<String> streamedFeedbackResponse =
-//         BehaviorSubject<String>();
-//     state = FeedbackProgress.onProgress;
+class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam, Result<BehaviorSubject<String>>> {
+  FeedbackProgress state = FeedbackProgress.init;
 
-//     String response = '';
+  @override
+  Result<BehaviorSubject<String>> call(GetQuestionFeedbackParam param) {
+    final BehaviorSubject<String> streamedAdviceResponse = BehaviorSubject<String>();
+    state = FeedbackProgress.onProgress;
 
-//     try {
-//       OpenAI.instance
-//           .onChatCompletionSSE(
-//         request: ChatCompleteText(
-//           messages: [
-//             Messages(
-//               role: Role.system,
-//               content: tr(LocaleKeys.undefined_interview_prompt),
-//             ),
-//             Messages(
-//               role: Role.system,
-//               content: tr(
-//                 LocaleKeys.undefined_user_name_prompt,
-//                 namedArgs: {'nickname': param.userName},
-//               ),
-//             ),
-//             Messages(
-//               role: Role.system,
-//               content: tr(
-//                 LocaleKeys.undefined_model_answer_prompt,
-//                 namedArgs: {
-//                   'relatedAnswer':
-//                       '${StoredTopics.getById(param.qna.qna.id.getFirstPartOfSpliited)}',
-//                   'question': param.question,
-//                   'modelAnswer':
-//                       param.qna.qna.answers.map((str) => '-$str').join(' '),
-//                 },
-//               ),
-//             ),
-//             Messages(
-//               role: Role.user,
-//               content: param.userAnswer,
-//             ),
-//             Messages(
-//               role: Role.system,
-//               content: tr(
-//                 LocaleKeys.undefined_user_answer_prompt,
-//                 namedArgs: {
-//                   'nickname': param.userName,
-//                   'answer': param.userAnswer,
-//                 },
-//               ),
-//             ),
-//           ],
-//           maxToken: 300,
-//           model: Gpt4ChatModel(),
-//           temperature: 0.5,
-//           stream: true,
-//           user: FirebaseAuth.instance.currentUser!.uid,
-//         ),
-//       )
-//           .listen(
-//         (it) {
-//           /// 연속적인 응답 값을 반환 할때
-//           /// 1) 정답 여부 확인
-//           /// 2) 응답 텍스트 포맷
-//           /// 3) 스트림 값 삽입
+    String response = '';
+    String jsonResponse = '';
+    bool isCollectingJson = false;
 
-//           response += it.choices?.last.message?.content ?? '';
-//           setCorrectnessIfNeeded(response, param.checkAnswer);
-//           streamedFeedbackResponse.add(formatResponse(response));
-//         },
-//         onDone: () {
-//           /// 응답이 종료된 이후
-//           /// 1) Stream 닫기
-//           /// 2) 응답 진행 상태 초기화
-//           /// 3) 완료 콜백 메소드 실행
-//           state = FeedbackProgress.init;
-//           streamedFeedbackResponse.close().then(
-//                 (_) => param.onFeedBackCompleted(
-//                   formatResponse(streamedFeedbackResponse.value),
-//                 ),
-//               );
-//         },
-//       );
-//       return Result.success(streamedFeedbackResponse);
-//     } on Exception catch (e) {
-//       return Result.failure(e);
-//     }
-//   }
+    try {
+      OpenAI.instance
+          .onChatCompletionSSE(
+        request: ChatCompleteText(
+          functionCall: FunctionCall.auto,
+          messages: _createChatMessage(param),
+          maxToken: 300,
+          model: Gpt4ChatModel(),
+          temperature: 0.5,
+          stream: true,
+          user: FirebaseAuth.instance.currentUser!.uid,
+        ),
+      )
+          .listen(
+        (it) {
+          final chunk = it.choices?.last.message?.content ?? '';
 
-//   ///
-//   /// 정답 여부를 확인하는 메소드
-//   ///
-//   void setCorrectnessIfNeeded(
-//     String response,
-//     void Function({required bool isCorrect}) checkAnswer,
-//   ) {
-//     if (!state.isOnProgress) return;
+          if (chunk.isEmpty) return;
 
-//     if (response.contains(AnswerState.wrong.tag)) {
-//       checkAnswer(
-//         isCorrect: false,
-//       );
-//       state = FeedbackProgress.completed;
-//     } else if (response.contains(AnswerState.correct.tag)) {
-//       state = FeedbackProgress.completed;
-//       checkAnswer(
-//         isCorrect: true,
-//       );
-//     }
-//     HapticFeedback.lightImpact();
-//   }
+          if (_isStartingJsonCollection(chunk, isCollectingJson)) {
+            // JSON 수집 시작
+            isCollectingJson = true;
+            final jsonStartIndex = chunk.indexOf('{');
+            jsonResponse = chunk.substring(jsonStartIndex);
+            response += chunk.substring(0, jsonStartIndex);
+            streamedAdviceResponse.add(response); // JSON 이전의 데이터만 스트림에 추가
+          } else if (isCollectingJson) {
+            // JSON 수집 중
+            jsonResponse += chunk;
+          } else {
+            // JSON이 아닌 일반 텍스트 부분을 사용자에게 스트림으로 전달
+            response += chunk;
+          }
 
-//   /// 응답값 포맷
-//   /// 1. [c] & [w] 인디에키터 포맷, [AnswerState]
-//   /// 2. 불필요 줄바꿈 제거
-//   String formatResponse(String response) {
-//     String formattedText = response.replaceAll('\n', '');
+          _setCorrectnessIfNeeded(response, param.checkAnswer);
+          streamedAdviceResponse.add(formatResponse(response));
 
-//     if (formattedText.length <= 3) return '';
+          // JSON 데이터 수집 완료 여부 확인
+          if (_isJsonCollectionComplete(jsonResponse, isCollectingJson)) {
+            final feedback = _parseAndHandleJsonResponse(jsonResponse);
+            // TODO: 임시로 확인을 위해 출력, 추후 피드백 핸들링 추가 예정
+            print('score: ${feedback.score}\nfollowingQ: ${feedback.followUpQuestion}\ncause: ${feedback.cause}');
 
-//     if (formattedText.contains(AnswerState.wrong.tag)) {
-//       return formattedText.replaceFirst(AnswerState.wrong.tag, '').trim();
-//     } else {
-//       return formattedText.replaceFirst(AnswerState.correct.tag, '').trim();
-//     }
-//   }
-// }
+            jsonResponse = ''; // JSON 수집 상태 초기화
+            isCollectingJson = false;
+          }
+        },
+        onDone: () {
+          /// 응답이 종료된 이후
+          /// 1) Stream 닫기
+          /// 2) 응답 진행 상태 초기화
+          /// 3) 완료 콜백 메소드 실행
+          state = FeedbackProgress.init;
+          streamedAdviceResponse.close().then((_) {
+            String? streamedRes = streamedAdviceResponse.valueOrNull;
 
-// /// [SetAiFeedbackUseCase] 파라미터
-// typedef GetQuestionFeedbackParam = ({
-//   ChatQnaEntity qna,
-//   String question,
-//   String userAnswer,
-//   String userName,
-//   void Function(String feedback) onFeedBackCompleted,
-//   void Function({required bool isCorrect}) checkAnswer
-// });
+            if (streamedRes == null) {
+              return;
+            } else {
+              return param.onFeedBackCompleted(
+                formatResponse(streamedAdviceResponse.value),
+              );
+            }
+          });
+        },
+      );
+      return Result.success(streamedAdviceResponse);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  /// 프롬프트 메세지 히스토리를 만드는 함수
+  /// 추후에 메세지 히스토리 기반으로 채팅을 구현할 수도 있을 것 같아 따로 분리했습니다.
+  List<Map<String, dynamic>> _createChatMessage(GetQuestionFeedbackParam param) {
+    // 프롬프트는 추후 전부 한 언어로 통일할 것이므로 따로 localization은 필요하지 않아 보입니다.
+    return [
+      Messages(
+        role: Role.system,
+        content:
+            '면접 질문을 물어보고 유저 답변의 정답 여부를 확인합니다. 당신은 면접관, 유저는 지원자입니다. 이제부터 진행할 면접은 ${StoredTopics.getById(param.qna.qna.id.getFirstPartOfSpliited)}와 관련된 질문입니다. 지원자의 이름은 \'${param.userName}\'입니다. 유저를 지칭할 때 항상 이름으로 불러주세요. ${AppLocale.currentLocale.languageCode}언어로 면접을 진행합니다.',
+      ).toJson(),
+      Messages(role: Role.assistant, content: param.question).toJson(),
+      Messages(
+        role: Role.user,
+        content: param.userAnswer,
+      ).toJson(),
+      Messages(
+        role: Role.system,
+        content: '면접 질문에 대한 모범답안은 다음과 같습니다: ${param.qna.qna.answers.map((str) => '-$str').join(' ')}',
+      ).toJson(),
+      Messages(
+        role: Role.system,
+        content:
+            '먼저 유저의 답변에 대한 피드백을 80글자 이내의 문자열 형태로 반드시 제공해야 합니다. 조언 가장 앞에 면접자의 답변이 틀렸다면 [w]를, 답변이 맞았다고 판단되면 [c]를 붙입니다. 조언을 제공한 다음, 유저의 답변에 대한 점수를 0~5점까지로 매긴 뒤 점수가 1점 이상이고 면접자가 주제에 대한 심화적인 이해를 가지고 있는지 확인하기 위한 꼬리질문이 필요할 경우 JSON 형식으로 0~5점 사이의 점수, 꼬리질문, 꼬리질문이 필요한 이유를 제공해주세요. 꼬리질문은 제시된 질문과 연관이 있어야 합니다. JSON 형식은 {"score": 점수, "followUpQuestion": "꼬리 질문", "cause": "꼬리질문이 나온 이유" }입니다.',
+      ).toJson(),
+    ];
+  }
+
+  bool _isStartingJsonCollection(String chunk, bool isCollectingJson) {
+    return !isCollectingJson && chunk.contains('{');
+  }
+
+  bool _isJsonCollectionComplete(String jsonResponse, bool isCollectingJson) {
+    return isCollectingJson && jsonResponse.contains('}');
+  }
+
+  FeedbackResponse _parseAndHandleJsonResponse(String jsonResponse) {
+    final parsedData = _parseJsonResponse(jsonResponse);
+    return FeedbackResponse.fromJson(parsedData);
+  }
+
+  /// 응답에서 점수와 꼬리질문을 JSON 형식으로 파싱하는 함수
+  Map<String, dynamic> _parseJsonResponse(String response) {
+    try {
+      return jsonDecode(response) as Map<String, dynamic>;
+    } catch (e) {
+      return {
+        "score": 0,
+        "followUpQuestion": null,
+      };
+    }
+  }
+
+  ///
+  /// 정답 여부를 확인하는 메소드
+  ///
+  void _setCorrectnessIfNeeded(
+    String response,
+    void Function({required AnswerState answerState}) checkAnswer,
+  ) {
+    if (!state.isOnProgress) return;
+
+    late final AnswerState answerState;
+
+    // 모든 AnswerState 값을 순회하면서 적절한 상태를 찾음
+    answerState = AnswerState.values.firstWhere(
+      (state) => response.contains(state.tag),
+      orElse: () => AnswerState.loading,
+    );
+
+    switch (answerState) {
+      case AnswerState.loading:
+        break;
+      case AnswerState.initial:
+      case AnswerState.error:
+      case AnswerState.correct:
+      case AnswerState.wrong:
+      case AnswerState.inappropriate:
+        HapticFeedback.lightImpact();
+        state = FeedbackProgress.completed;
+        checkAnswer.call(answerState: answerState);
+    }
+  }
+
+  /// 응답값 포맷
+  /// 1. [c] & [w] 인디에키터 포맷, [AnswerState]
+  /// 2. 불필요 줄바꿈 제거
+  String formatResponse(String response) {
+    String formattedText = response.replaceAll('\n', '').trim();
+
+    if (formattedText.length <= 3) return '';
+
+    for (final state in AnswerState.values) {
+      if (formattedText.contains(state.tag)) {
+        return formattedText.replaceFirst(state.tag, '').trim();
+      }
+    }
+
+    return formattedText;
+  }
+}
+
+// TODO: 추후에 클래스 정리하면서 꼬리질문 UI 구현시 사용 예정, 임시로 여기 위치시키겠습니다.
+/// JSON 응답을 담을 클래스
+class FeedbackResponse {
+  final int score;
+  final String? followUpQuestion;
+  final String? cause;
+
+  FeedbackResponse({
+    required this.score,
+    this.followUpQuestion,
+    this.cause,
+  });
+
+  factory FeedbackResponse.fromJson(Map<String, dynamic> json) {
+    return FeedbackResponse(
+      score: json['score'],
+      followUpQuestion: json['followUpQuestion'],
+      cause: json['cause'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'score': score,
+      'followUpQuestion': followUpQuestion,
+    };
+  }
+}
+
+/// [SetAiFeedbackUseCase] 파라미터
+typedef GetQuestionFeedbackParam = ({
+  ChatQnaEntity qna,
+  String question,
+  String userAnswer,
+  String userName,
+  void Function(String feedback) onFeedBackCompleted,
+  void Function({required AnswerState answerState}) checkAnswer
+});

--- a/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
@@ -39,6 +39,8 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
 
           if (chunk.isEmpty) return;
 
+          print(chunk);
+
           if (_isStartingJsonCollection(chunk, isCollectingJson)) {
             // JSON 수집 시작
             isCollectingJson = true;
@@ -61,7 +63,7 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
           if (_isJsonCollectionComplete(jsonResponse, isCollectingJson)) {
             final feedback = _parseAndHandleJsonResponse(jsonResponse);
             // TODO: 임시로 확인을 위해 출력, 추후 피드백 핸들링 추가 예정
-            print('score: ${feedback.score}\nfollowingQ: ${feedback.followUpQuestion}\ncause: ${feedback.cause}');
+            print('score: ${feedback.score}\n followingQ: ${feedback.followUpQuestion}\n cause: ${feedback.cause}');
 
             jsonResponse = ''; // JSON 수집 상태 초기화
             isCollectingJson = false;
@@ -114,7 +116,8 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
       Messages(
         role: Role.system,
         content:
-            '먼저 유저의 답변에 대한 피드백을 80글자 이내의 문자열 형태로 반드시 제공해야 합니다. 조언 가장 앞에 면접자의 답변이 틀렸다면 [w]를, 답변이 맞았다고 판단되면 [c]를 붙입니다. 조언을 제공한 다음, 유저의 답변에 대한 점수를 0~5점까지로 매긴 뒤 점수가 1점 이상이고 면접자가 주제에 대한 심화적인 이해를 가지고 있는지 확인하기 위한 꼬리질문이 필요할 경우 JSON 형식으로 0~5점 사이의 점수, 꼬리질문, 꼬리질문이 필요한 이유를 제공해주세요. 꼬리질문은 제시된 질문과 연관이 있어야 합니다. JSON 형식은 {"score": 점수, "followUpQuestion": "꼬리 질문", "cause": "꼬리질문이 나온 이유" }입니다.',
+            '먼저 유저의 답변에 대한 피드백을 80글자 이내의 문자열 형태로 반드시 제공해야 합니다. 조언 가장 앞에 면접자의 답변이 틀렸다면 [w]를, 답변이 맞았다고 판단되면 [c]를 붙입니다. 조언을 제공한 다음, 유저의 답변에 대한 점수를 0~5점까지로 매긴 뒤 점수가 1점 이상이고 면접자가 주제에 대한 심화적인 이해를 가지고 있는지 확인하기 위한 꼬리질문이 필요할 경우 JSON 형식으로 0~5점 사이의 점수, 꼬리질문, 꼬리질문이 필요한 이유를 제공해주세요. 꼬리질문은 제시된 질문과 연관이 있어야 합니다. JSON 형식은 {"score": 점수, "followUpQuestion": "꼬리 질문", "cause": "꼬리질문이 나온 이유" }입니다. score은 필수값입니다',
+        // '''You must first provide feedback on the user's answer in a string of 80 characters or less. Start the feedback with [w] if the answer is incorrect, or [c] if it is correct. After giving feedback, assign a score between 0 and 5. If the score is 1 or higher, you must provide a follow-up question to assess deeper understanding, along with the reason in JSON format: {"score": score, "followUpQuestion": "follow-up question", "cause": "reason for follow-up question"}. The follow-up question should be related to the original question. The score is mandatory.''',
       ).toJson(),
     ];
   }

--- a/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
@@ -109,6 +109,21 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
         role: Role.system,
         content: '면접 질문에 대한 모범답안은 다음과 같습니다: ${param.qna.qna.answers.map((str) => '-$str').join(' ')}',
       ).toJson(),
+
+      /// 꼬리 질문 히스토리가 있다면 꼬리질문 히스토리를 제공합니다.
+      ...param.qna.followUpQuestions?.expand((followUpQ) {
+            return [
+              Messages(
+                role: Role.assistant,
+                content: followUpQ.qna.question,
+              ).toJson(),
+              Messages(
+                role: Role.user,
+                content: followUpQ.message?.message.value,
+              ).toJson(),
+            ];
+          }).toList() ??
+          [],
       Messages(
         role: Role.system,
         content:

--- a/lib/features/chat/use_cases/set_gemini_ai_feedback_use_case.dart
+++ b/lib/features/chat/use_cases/set_gemini_ai_feedback_use_case.dart
@@ -1,162 +1,162 @@
-import 'dart:developer';
+// import 'dart:developer';
 
-import 'package:flutter/services.dart';
-import 'package:google_generative_ai/google_generative_ai.dart';
-import 'package:rxdart/rxdart.dart';
-import 'package:techtalk/app/environment/flavor.dart';
-import 'package:techtalk/app/localization/app_locale.dart';
-import 'package:techtalk/core/index.dart';
-import 'package:techtalk/features/chat/chat.dart';
+// import 'package:flutter/services.dart';
+// import 'package:google_generative_ai/google_generative_ai.dart';
+// import 'package:rxdart/rxdart.dart';
+// import 'package:techtalk/app/environment/flavor.dart';
+// import 'package:techtalk/app/localization/app_locale.dart';
+// import 'package:techtalk/core/index.dart';
+// import 'package:techtalk/features/chat/chat.dart';
 
-/// gemini-1.5-pro-001 모델에서는 한정된 SafetySetting만 가능
-final safetySettings = [
-  SafetySetting(HarmCategory.harassment, HarmBlockThreshold.none),
-  SafetySetting(HarmCategory.hateSpeech, HarmBlockThreshold.none),
-];
+// /// gemini-1.5-pro-001 모델에서는 한정된 SafetySetting만 가능
+// final safetySettings = [
+//   SafetySetting(HarmCategory.harassment, HarmBlockThreshold.none),
+//   SafetySetting(HarmCategory.hateSpeech, HarmBlockThreshold.none),
+// ];
 
-final gemini = GenerativeModel(
-  model: 'gemini-1.5-pro-001',
-  apiKey: Flavor.env.geminiApiKey,
-  systemInstruction: Content.system(
-    'You are an interviewer, and the user is an applicant for a developer position. Please conduct the conversation naturally, as if you were an interviewer from a real company.',
-  ),
-  safetySettings: safetySettings,
-);
+// final gemini = GenerativeModel(
+//   model: 'gemini-1.5-pro-001',
+//   apiKey: Flavor.env.geminiApiKey,
+//   systemInstruction: Content.system(
+//     'You are an interviewer, and the user is an applicant for a developer position. Please conduct the conversation naturally, as if you were an interviewer from a real company.',
+//   ),
+//   safetySettings: safetySettings,
+// );
 
-class SetGeminiAiFeedbackUseCase extends BaseNoFutureUseCase<
-    GetQuestionFeedbackParam, Result<BehaviorSubject<String>>> {
-  ///
-  /// 피드백 진행 상태
-  ///
-  FeedbackProgress state = FeedbackProgress.init;
+// class SetGeminiAiFeedbackUseCase extends BaseNoFutureUseCase<
+//     GetQuestionFeedbackParam, Result<BehaviorSubject<String>>> {
+//   ///
+//   /// 피드백 진행 상태
+//   ///
+//   FeedbackProgress state = FeedbackProgress.init;
 
-  ///
-  /// 면접 질문에 대한 유저의 응답의 정답여부를 확인
-  /// propmt 로직을 고도화 할 필요 있음.
-  ///
-  @override
-  Result<BehaviorSubject<String>> call(GetQuestionFeedbackParam param) {
-    final BehaviorSubject<String> streamedFeedbackResponse =
-        BehaviorSubject<String>();
-    state = FeedbackProgress.onProgress;
+//   ///
+//   /// 면접 질문에 대한 유저의 응답의 정답여부를 확인
+//   /// propmt 로직을 고도화 할 필요 있음.
+//   ///
+//   @override
+//   Result<BehaviorSubject<String>> call(GetQuestionFeedbackParam param) {
+//     final BehaviorSubject<String> streamedFeedbackResponse =
+//         BehaviorSubject<String>();
+//     state = FeedbackProgress.onProgress;
 
-    String response = '';
+//     String response = '';
 
-    try {
-      gemini.generateContentStream(
-        [
-          Content.text('''
-      You will ask an interview question and verify the correctness of the user's answer.
+//     try {
+//       gemini.generateContentStream(
+//         [
+//           Content.text('''
+//       You will ask an interview question and verify the correctness of the user's answer.
 
-      The question is related to ${StoredTopics.getById(param.qna.qna.id.getFirstPartOfSpliited)}.
-      The question presented is: ${param.question}.
-      The correct answer is: ${param.qna.qna.answers.map((str) => '-$str').join(' ')}'
-      I answered: "${param.userAnswer}".  
+//       The question is related to ${StoredTopics.getById(param.qna.qna.id.getFirstPartOfSpliited)}.
+//       The question presented is: ${param.question}.
+//       The correct answer is: ${param.qna.qna.answers.map((str) => '-$str').join(' ')}'
+//       I answered: "${param.userAnswer}".  
   
-      Based on the correct answer provided, determine whether response is correct by prefixing your response with "[c]" if it is correct, or "[w]" if it is incorrect.
-      Provide a technical explanation(don't ask additional question) of up to 120 characters regarding the correctness and quality of the answer.
+//       Based on the correct answer provided, determine whether response is correct by prefixing your response with "[c]" if it is correct, or "[w]" if it is incorrect.
+//       Provide a technical explanation(don't ask additional question) of up to 120 characters regarding the correctness and quality of the answer.
 
-      If ${param.userAnswer} contains inappropriate or offensive content, respond with "[x]" indicating that the answer is unacceptable. Provide a brief explanation of why the answer is not suitable and how it should be appropriately addressed.
+//       If ${param.userAnswer} contains inappropriate or offensive content, respond with "[x]" indicating that the answer is unacceptable. Provide a brief explanation of why the answer is not suitable and how it should be appropriately addressed.
           
-      Please respond in the language corresponding to language code "${AppLocale.currentLocale.languageCode}".
-'''),
-        ],
-        generationConfig: GenerationConfig(
-          temperature: 0.3,
-          maxOutputTokens: 300,
-        ),
-      ).listen(
-        (it) {
-          /// 연속적인 응답 값을 반환 할때
-          /// 1) 정답 여부 확인
-          /// 2) 응답 텍스트 포맷
-          /// 3) 스트림 값 삽입
+//       Please respond in the language corresponding to language code "${AppLocale.currentLocale.languageCode}".
+// '''),
+//         ],
+//         generationConfig: GenerationConfig(
+//           temperature: 0.3,
+//           maxOutputTokens: 300,
+//         ),
+//       ).listen(
+//         (it) {
+//           /// 연속적인 응답 값을 반환 할때
+//           /// 1) 정답 여부 확인
+//           /// 2) 응답 텍스트 포맷
+//           /// 3) 스트림 값 삽입
 
-          response += it.text ?? '';
+//           response += it.text ?? '';
 
-          if (response.length >= 3) {
-            setCorrectnessIfNeeded(response, param.checkAnswer);
-            streamedFeedbackResponse.add(formatResponse(response));
-          }
-        },
-        onError: (e) {
-          param.checkAnswer.call(answerState: AnswerState.error);
-          log('ai 응답 실패 : $e');
-        },
-      ).onDone(() {
-        /// 응답이 종료된 이후
-        /// 1) Stream 닫기
-        /// 2) 응답 진행 상태 초기화
-        /// 3) 완료 콜백 메소드 실행
-        state = FeedbackProgress.init;
-        streamedFeedbackResponse.close().then((_) {
-          String? streamedRes = streamedFeedbackResponse.valueOrNull;
+//           if (response.length >= 3) {
+//             setCorrectnessIfNeeded(response, param.checkAnswer);
+//             streamedFeedbackResponse.add(formatResponse(response));
+//           }
+//         },
+//         onError: (e) {
+//           param.checkAnswer.call(answerState: AnswerState.error);
+//           log('ai 응답 실패 : $e');
+//         },
+//       ).onDone(() {
+//         /// 응답이 종료된 이후
+//         /// 1) Stream 닫기
+//         /// 2) 응답 진행 상태 초기화
+//         /// 3) 완료 콜백 메소드 실행
+//         state = FeedbackProgress.init;
+//         streamedFeedbackResponse.close().then((_) {
+//           String? streamedRes = streamedFeedbackResponse.valueOrNull;
 
-          if (streamedRes == null) {
-            return;
-          } else {
-            return param.onFeedBackCompleted(
-              formatResponse(streamedFeedbackResponse.value),
-            );
-          }
-        });
-      });
+//           if (streamedRes == null) {
+//             return;
+//           } else {
+//             return param.onFeedBackCompleted(
+//               formatResponse(streamedFeedbackResponse.value),
+//             );
+//           }
+//         });
+//       });
 
-      return Result.success(streamedFeedbackResponse);
-    } on Exception catch (e) {
-      return Result.failure(e);
-    }
-  }
+//       return Result.success(streamedFeedbackResponse);
+//     } on Exception catch (e) {
+//       return Result.failure(e);
+//     }
+//   }
 
-  ///
-  /// 정답 여부를 확인하는 메소드
-  ///
-  void setCorrectnessIfNeeded(
-    String response,
-    void Function({required AnswerState answerState}) checkAnswer,
-  ) {
-    if (!state.isOnProgress) return;
+//   ///
+//   /// 정답 여부를 확인하는 메소드
+//   ///
+//   void setCorrectnessIfNeeded(
+//     String response,
+//     void Function({required AnswerState answerState}) checkAnswer,
+//   ) {
+//     if (!state.isOnProgress) return;
 
 
-    late final AnswerState answerState;
+//     late final AnswerState answerState;
 
-    // 모든 AnswerState 값을 순회하면서 적절한 상태를 찾음
-    answerState = AnswerState.values.firstWhere(
-      (state) {
-        return response.contains(state.tag);
-      },
-      orElse: () => AnswerState.loading,
-    );
+//     // 모든 AnswerState 값을 순회하면서 적절한 상태를 찾음
+//     answerState = AnswerState.values.firstWhere(
+//       (state) {
+//         return response.contains(state.tag);
+//       },
+//       orElse: () => AnswerState.loading,
+//     );
 
-    HapticFeedback.lightImpact();
-    state = FeedbackProgress.completed;
-    checkAnswer.call(answerState: answerState);
-  }
+//     HapticFeedback.lightImpact();
+//     state = FeedbackProgress.completed;
+//     checkAnswer.call(answerState: answerState);
+//   }
 
-  /// 응답값 포맷
-  /// 1. [c] & [w] 인디에키터 포맷, [AnswerState]
-  /// 2. 불필요 줄바꿈 제거
-  String formatResponse(String response) {
-    String formattedText = response.replaceAll('\n', '').trim();
+//   /// 응답값 포맷
+//   /// 1. [c] & [w] 인디에키터 포맷, [AnswerState]
+//   /// 2. 불필요 줄바꿈 제거
+//   String formatResponse(String response) {
+//     String formattedText = response.replaceAll('\n', '').trim();
 
-    if (formattedText.length <= 3) return '';
+//     if (formattedText.length <= 3) return '';
 
-    for (final state in AnswerState.values) {
-      if (formattedText.contains(state.tag)) {
-        return formattedText.replaceFirst(state.tag, '').trim();
-      }
-    }
+//     for (final state in AnswerState.values) {
+//       if (formattedText.contains(state.tag)) {
+//         return formattedText.replaceFirst(state.tag, '').trim();
+//       }
+//     }
 
-    return formattedText;
-  }
-}
+//     return formattedText;
+//   }
+// }
 
-/// [SetGeminiAiFeedbackUseCase] 파라미터
-typedef GetQuestionFeedbackParam = ({
-  ChatQnaEntity qna,
-  String question,
-  String userAnswer,
-  String userName,
-  void Function(String feedback) onFeedBackCompleted,
-  void Function({required AnswerState answerState}) checkAnswer
-});
+// /// [SetGeminiAiFeedbackUseCase] 파라미터
+// typedef GetQuestionFeedbackParam = ({
+//   ChatQnaEntity qna,
+//   String question,
+//   String userAnswer,
+//   String userName,
+//   void Function(String feedback) onFeedBackCompleted,
+//   void Function({required AnswerState answerState}) checkAnswer
+// });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
 
   #Gemini
   google_generative_ai: ^0.4.3
+  chat_gpt_sdk: ^3.1.0
 
   # UI
   cupertino_will_pop_scope: ^1.2.1 #pop scope (스와이프 백 제스쳐 지원)


### PR DESCRIPTION
## 📝 변경 내용
- https://github.com/MakeFrog/TechTalk/issues/117
- 프롬프트 수정
  - stream을 위해 필요한 영역은 String, 꼬리질문 및 점수 영역은 json으로 받도록 프롬프트 수정
  - 프롬프트 순서와 내용을 변경함, system과 assistant, user로 구분
  - 현재, **영어로 번역하여 프롬프트 할 경우 정확도가 떨어져, 한국어로 프롬프팅** 하였습니다
    - 한국어로 프롬프트를 만들었을 때, 꼬리질문 퀄리티와 조언 퀄리티가 더 높네요. 추후에 확인 필요합니다

[240907 확정 내용]
사용자에 답변에 대한 피드백, 점수, 꼬리질문 필요 여부만 제공받은 후에, 꼬리질문 필요 여부에 따라 별도의 usecase에서 꼬리질문을 생성하는 방식으로 진행하겠습니다.

<br>

## 🔍 변경 이유
* 추후 꼬리질문 존재 여부에 따라 꼬리질문 데이터를 클래스 형태로 앱 내에서 핸들링 하기 위함
* 프롬프트 효율화를 위해 일부 순서와 내용 변경

<br>

## 🌍 영향
* 꼬리질문 영역은 stream으로 모은 후에 json으로 파싱하므로, 조언 String이 채팅에 표시된 이후에도 로딩이 일부 지속될 수 있음 -> 해당 부분은 논의가 필요할 듯 합니다.
* 한국어 프롬프팅 되어 있는 상황으로, 추후 영어로 변경 테스트가 필요합니다.


<br>

## 👥 리뷰어
* @Xim-ya @yundal8755 

