### PR TITLE
[면접] AOS speech to text 오류 수정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,11 @@
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
    <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -501,7 +501,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -585,7 +585,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -668,7 +668,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -751,7 +751,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -891,7 +891,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -921,7 +921,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/lib/app/environment/flavor.dart
+++ b/lib/app/environment/flavor.dart
@@ -46,12 +46,16 @@ class Flavor {
     /// 채팅 면접에서 사용되는 OepnAI SK
     OpenAI.instance.build(
       token: env.openApiKey,
-      baseOption: HttpSetup(receiveTimeout: const Duration(seconds: 10), connectTimeout: const Duration(seconds: 10)),
+      baseOption: HttpSetup(
+          receiveTimeout: const Duration(seconds: 10),
+          connectTimeout: const Duration(seconds: 10)),
       enableLog: true,
     );
 
     /// whisper 모델을 제공하는 OpenAI SDK
-    forWhisper.OpenAI.apiKey =  env.openApiKey;
+    forWhisper.OpenAI.apiKey = env.openApiKey;
+    forWhisper.OpenAI.requestsTimeOut = const Duration(seconds: 12);
+
 
     /// 앱 DI 실행
     await AppBinder.init();

--- a/lib/presentation/pages/interview/chat/providers/speech_to_text_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/speech_to_text_provider.dart
@@ -124,7 +124,6 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
     await recordedText.fold(onSuccess: (text) async {
       if (Platform.isAndroid &&
           _ghostWords.any((element) => text.contains(element))) {
-        print('아지랑이 : ${text}');
         SnackBarService.showSnackBar(tr(LocaleKeys.interview_noAudioDetected));
         await File(recordPath).delete();
         _updateProgressState(RecordProgressState.initial);

--- a/lib/presentation/pages/interview/chat/providers/speech_to_text_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/speech_to_text_provider.dart
@@ -28,7 +28,7 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
 
   /// 음성 녹음 컨트롤러
   final recordController = AudioRecorder();
-  final speechController = SpeechToText();
+  late final speechController = Platform.isIOS ? SpeechToText() : null;
 
   //// speech 컨트롤러 listen 가능 상태 여부
   Completer<void> isSpeechListenAvailable = Completer<void>();
@@ -41,6 +41,14 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
 
   /// 음성 녹음 파일이 저장되는 경로
   late String recordPath;
+
+  /// 아무 음성을 인식하지 않고 whisper 모델을 실행했을 때 발생하는 텍스트\
+  /// ko버전
+  final List<String> _ghostWords = [
+    'MBC 뉴스 이덕영입니다',
+    '시청해주셔서',
+    '. .',
+  ];
 
   ///
   /// 타이핑 모드 버튼 클릭시
@@ -98,20 +106,31 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
     /// 녹음 중지
     await recordController.stop();
 
-    await isSpeechListenAvailable.future;
+    if (Platform.isIOS) {
+      await isSpeechListenAvailable.future;
 
-    /// 입력된 텍스트가 없다면 알럿을 노출 후 초기화 상태로 변경
-    if (notifyText.isEmpty) {
-      SnackBarService.showSnackBar(tr(LocaleKeys.interview_noAudioDetected));
-      await File(recordPath).delete();
-      _updateProgressState(RecordProgressState.initial);
-      return;
+      /// 입력된 텍스트가 없다면 알럿을 노출 후 초기화 상태로 변경
+      if (notifyText.isEmpty) {
+        SnackBarService.showSnackBar(tr(LocaleKeys.interview_noAudioDetected));
+        await File(recordPath).delete();
+        _updateProgressState(RecordProgressState.initial);
+        return;
+      }
     }
 
     /// 녹음된 텍스트 (Speech To Text)
     final recordedText = await recordToTextUseCase.call(recordPath);
 
     await recordedText.fold(onSuccess: (text) async {
+      if (Platform.isAndroid &&
+          _ghostWords.any((element) => text.contains(element))) {
+        print('아지랑이 : ${text}');
+        SnackBarService.showSnackBar(tr(LocaleKeys.interview_noAudioDetected));
+        await File(recordPath).delete();
+        _updateProgressState(RecordProgressState.initial);
+        return;
+      }
+
       /// 기존 텍스트 입력폼에 저장되어 있던 텍스트와 녹음된 텍스트 병합
       final textFiledController = ref.read(mainInputControllerProvider);
       await File(recordPath).delete();
@@ -164,8 +183,10 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
       if (progressState.isOnProgress || progressState.isReady) {
         _updateProgressState(RecordProgressState.loading);
         notifyListeners();
-        unawaited(
-            Future.wait([recordController.stop(), speechController.cancel()]));
+        unawaited(Future.wait([
+          recordController.stop(),
+          if (Platform.isIOS) speechController!.cancel() else Future.value()
+        ]));
       }
 
       _updateProgressState(RecordProgressState.initial, resetText: true);
@@ -182,9 +203,9 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
   /// SpeechToText 컨트롤러 초기화
   ///
   Future<void> initializeSpeechController() async {
-    final isEnabled = await speechController.initialize();
+    final isEnabled = await speechController!.initialize();
     if (isEnabled) {
-      await speechController.listen(onResult: (result) {
+      await speechController!.listen(onResult: (result) {
         if (progressState.isOnProgress) {
           notifyText = result.recognizedWords;
           notifyListeners();
@@ -193,7 +214,7 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
 
       isSpeechListenAvailable.complete(null);
     } else {
-      unawaited(speechController.cancel());
+      unawaited(speechController!.cancel());
     }
   }
 
@@ -215,7 +236,9 @@ class SpeechToTextProvider extends ChangeNotifier with ChatEvent {
       await File(recordPath).delete();
     }
 
-    await initializeSpeechController();
+    if (Platform.isIOS) {
+      await initializeSpeechController();
+    }
   }
 }
 
@@ -224,7 +247,9 @@ final speechToTextProvider = AutoDisposeChangeNotifierProvider((ref) {
   provider.initConfigSettings();
 
   ref.onDispose(() {
-    provider.speechController.cancel();
+    if (Platform.isIOS) {
+      provider.speechController!.cancel();
+    }
     provider.recordController.dispose();
   });
   return provider;

--- a/lib/presentation/pages/interview/chat/widgets/interview_tab_view/rounded_mic_motion_view.dart
+++ b/lib/presentation/pages/interview/chat/widgets/interview_tab_view/rounded_mic_motion_view.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -134,24 +136,31 @@ class RoundedMicMotionView extends HookConsumerWidget {
                                 duration: const Duration(milliseconds: 1650),
                               );
 
-                              ref.listen(
-                                  speechToTextProvider.select(
-                                      (p) => p.notifyText), (prev, now) {
-                                if (now.isNotEmpty) {
-                                  // 텍스트가 입력되면 애니메이션 반복 실행
+                              if (Platform.isIOS) {
+                                ref.listen(
+                                    speechToTextProvider.select(
+                                        (p) => p.notifyText), (prev, now) {
+                                  if (now.isNotEmpty) {
+                                    // 텍스트가 입력되면 애니메이션 반복 실행
 
-                                  if (!animationController.isAnimating) {
-                                    animationController.repeat();
-                                  }
-
-                                  debouncer.run(() async {
-                                    if (animationController.isAnimating) {
-                                      await animationController.forward();
-                                      animationController.stop();
+                                    if (!animationController.isAnimating) {
+                                      animationController.repeat();
                                     }
-                                  });
-                                }
-                              });
+
+                                    debouncer.run(() async {
+                                      if (animationController.isAnimating) {
+                                        await animationController.forward();
+                                        animationController.stop();
+                                      }
+                                    });
+                                  }
+                                });
+                              } else {
+                                useEffect(() {
+                                  animationController.repeat();
+                                  return null;
+                                }, []);
+                              }
 
                               return StaggeredDotsWave(
                                 size: 24,

--- a/lib/presentation/widgets/common/dialog/app_dialog.dart
+++ b/lib/presentation/widgets/common/dialog/app_dialog.dart
@@ -173,7 +173,10 @@ class AppDialog extends Dialog {
                                 ),
                                 textStyle: AppTextStyle.title1,
                               ),
-                              child: Text(leftBtnText!),
+                              child: Text(
+                                leftBtnText!,
+                                textAlign: TextAlign.center,
+                              ),
                             ),
                           ),
                         ],
@@ -190,7 +193,10 @@ class AppDialog extends Dialog {
                           vertical: 13,
                         ),
                       ),
-                      child: Text(btnText!),
+                      child: Text(
+                        btnText!,
+                        textAlign: TextAlign.center,
+                      ),
                     ),
                   )
                 ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.5+18
+version: 1.0.5+20
 
 environment:
   sdk: ">=3.0.6 <4.0.0"


### PR DESCRIPTION
## 📝 어떤 문제가 발생했나요?
각종 음성 인식 관련 로직들을 구현하기 아래 네이티브 기능을 병렬적으로 사용함
- Record
- Text Recognition(Whisper ai)

iOS 환경에서는 2개의 기능을 동시에 사용해도 문제가 없지만, AOS에서는 보안상의 이유로 해당 기능을 동시에 사용하는것을 원천적으로 허용하지 않음. 이로인해 아래 기능이 제한됨.

- Recognize된 음성이 없을 경우 "입력된 녹음이 없어요" 라는 알럿 노출
- 음성이 Recognize 되었을 경우에만 음성 인식 활성화 애니메이션 실행
- 어떠한 음성을 입력하지 않은 상태로 종료했을 때 반복적으로 예상하지 못한 텍스트가 반환됨

<br>

## 어떻게 해결하였나요?
기술적으로 문제를 해결하기 위해서는 Record와 Text Recognition 기능을 AOS 환경에서 동시에 사용할 수 있는 방법을 찾거나, Whisper 모델을 튜닝할 필요가 있다고 판단했지만 공수가 많이 필요할것으로 판된되어 AOS 환경에서만 기능 자체를 일부 변경.

1. 음성 인식 여부와 상관없이 음성 인식을 실행 했을 때 '음성 인식 활성화' 애니메이션 실행
2. 반복적으로 나타나는 특정 텍스트 값을 기준으로 음성이 입력되었는 여부를 확인하는 방어 코드 추가

```dart
final List<String> _ghostWords = [
    'MBC 뉴스 이덕영입니다',
    '시청해주셔서',
    '. .',
  ];
  
/// _ghotsWords에 반환된 텍스트가 포함되는 패턴이 있으면 block
     if (Platform.isAndroid &&
          _ghostWords.any((element) => text.contains(element))) {
        SnackBarService.showSnackBar(tr(LocaleKeys.interview_noAudioDetected));
        await File(recordPath).delete();
        _updateProgressState(RecordProgressState.initial);
        return;
      }
``` 



<br>

## 📌 기타 사항
해당 이슈는 백로그에 남겨두고 계속 고민해야될 것 같아요. 
다행히 한국어 언어로 설정되어 있을 때, 이상하게 반환되는 텍스트 인식 결과의 패턴이 어느정도 동일해서 큰 문제가 없을 것 같은데... 영어 언어로 설정될 경우 여러 가지 패턴으로 오류 텍스트가 반환되어 방어코드를 작성하기 힘들어 보입니다.

<br>
