### PR TITLE
[홈, 면접 주제 선택] 라우팅 이벤트 수정 

### DIFF
--- a/assets/translations/ko.json
+++ b/assets/translations/ko.json
@@ -182,7 +182,7 @@
   },
   "mistakeNote": {
     "noMistakeRecords": "아직 오답 기록이 없어요.",
-    "letsHaveInterview": "Let's have a {tech} interview!",
+    "letsHaveInterview": "{tech} 주제로 면접을 진행해보세요!",
     "wrongManyTimes": "여러 번 틀린 문제"
   },
   "myInfo": {

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -490,7 +490,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = YD8Z9K9UT3;
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/app/entrypoints/main_dev.dart;
@@ -501,7 +501,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -574,7 +574,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = YD8Z9K9UT3;
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/app/entrypoints/main_dev.dart;
@@ -585,7 +585,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -657,7 +657,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = YD8Z9K9UT3;
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/app/entrypoints/main_prod.dart;
@@ -668,7 +668,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -740,7 +740,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = YD8Z9K9UT3;
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/app/entrypoints/main_dev.dart;
@@ -751,7 +751,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -880,7 +880,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = YD8Z9K9UT3;
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/app/entrypoints/main_prod.dart;
@@ -891,7 +891,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -910,7 +910,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_TEAM = YD8Z9K9UT3;
 				ENABLE_BITCODE = NO;
 				FLUTTER_TARGET = lib/app/entrypoints/main_prod.dart;
@@ -921,7 +921,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.techtalk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";

--- a/lib/app/environment/environment.enum.dart
+++ b/lib/app/environment/environment.enum.dart
@@ -1,7 +1,9 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:techtalk/app/environment/firebase/firebase_options.dart' as prod_firebase;
-import 'package:techtalk/app/environment/firebase/firebase_options_dev.dart' as dev_firebase;
+import 'package:techtalk/app/environment/firebase/firebase_options.dart'
+    as prod_firebase;
+import 'package:techtalk/app/environment/firebase/firebase_options_dev.dart'
+    as dev_firebase;
 
 enum Environment {
   dev(type: "DEV", firebaseId: "techtalk-dev-33"),
@@ -28,6 +30,11 @@ enum Environment {
   String get geminiApiKey => switch (this) {
         dev => dotenv.env['GEMINI_API_KEY']!,
         prod => dotenv.env['GEMINI_API_KEY']!,
+      };
+
+  String get slackNotificationKey => switch (this) {
+        dev => dotenv.env['SLACK_NOTIFICATION_KEY']!,
+        prod => dotenv.env['SLACK_NOTIFICATION_KEY']!,
       };
 
   FirebaseOptions get firebaseOption => switch (this) {

--- a/lib/core/constants/slack_notification_type.enum.dart
+++ b/lib/core/constants/slack_notification_type.enum.dart
@@ -1,0 +1,14 @@
+///
+/// Slack Notification 타입
+///
+enum SlackNotificationType {
+  signUp(':rocket:'),
+  logOut(':hanKey:'),
+  login(':door:'),
+  event(':fire:'),
+  withdraw(':cry:');
+
+  final String icon;
+
+  const SlackNotificationType(this.icon);
+}

--- a/lib/core/services/slack_notification_service.dart
+++ b/lib/core/services/slack_notification_service.dart
@@ -1,0 +1,109 @@
+import 'dart:developer';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:techtalk/app/environment/environment.enum.dart';
+import 'package:techtalk/app/environment/flavor.dart';
+import 'package:techtalk/app/localization/app_locale.dart';
+import 'dart:convert';
+import 'package:techtalk/core/constants/slack_notification_type.enum.dart';
+import 'package:techtalk/core/index.dart';
+import 'package:techtalk/features/user/repositories/entities/user_entity.dart';
+
+///
+/// 슬랙 노티피케이션 알람 모듈
+/// TODO: 추후 리팩토링 필요
+///
+
+abstract class SlackNotificationService {
+  static UserEntity? userInfo;
+
+  // Slack 알림을 보내는 함수
+  static Future<void> sendNotification(
+      {UserEntity? targetUserInfo,
+      String? message,
+      required SlackNotificationType type}) async {
+    // 데브 또는 디버그 모드에서는 이벤트 실행 X
+    if(kDebugMode.isTrue || Flavor.env == Environment.dev) return;
+    // 웹후크 URL
+    final url = Uri.parse(
+        'https://hooks.slack.com/services/T071LHJ83KK/B07QPDR2KBM/${Environment.prod.slackNotificationKey}');
+
+    final targetMessage = switch (type) {
+      SlackNotificationType.login => () async {
+          userInfo = targetUserInfo;
+          return targetUserInfo == null
+              ? '익명의 유저가 로그인을 했습니다'
+              : '${userInfo!.loginCount ?? 0 + 1}번째 로그인을 했습니다 (마지막 접속일 : ${timeAgo(userInfo!.lastLoginDate)})';
+        },
+      SlackNotificationType.event => () async {
+          return message ?? '등록이 필요한 이벤트 입니다';
+        },
+      SlackNotificationType.signUp => () async {
+          userInfo = targetUserInfo;
+          return '새로운 유저가 회원가입을 진행했어요!';
+        },
+      SlackNotificationType.withdraw => () async {
+          clear();
+          return '회원탈퇴 했어요';
+        },
+      SlackNotificationType.logOut => () async {
+          clear();
+          return '로그아웃 했어요';
+        },
+    };
+
+    // JSON 페이로드 생성
+    final payload = {
+      'channel': '이벤트-로그',
+      // 메시지를 보낼 채널
+      'username':
+          '${userInfo?.nickname ?? targetUserInfo?.nickname ?? '익명'}(${AppLocale.currentLocale.countryCode}/${AppLocale.currentLocale.languageCode})',
+      // 사용자 이름
+      'text': await targetMessage(),
+      // Slack에 표시될 텍스트
+      'icon_emoji': type.icon,
+      // 이모지
+    };
+
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(payload),
+    );
+
+    if (response.statusCode == 200) {
+      log('Slack notification sent successfully');
+    } else {
+      log('Failed to send notification: ${response.statusCode}');
+    }
+  }
+
+  static void updateUserInfo(UserEntity? info) {
+    userInfo = info;
+  }
+
+  static void clear() {
+    userInfo = null;
+  }
+}
+
+String timeAgo(DateTime inputTime) {
+  final now = DateTime.now();
+  final difference = now.difference(inputTime);
+
+  if (difference.inSeconds < 60) {
+    return '${difference.inSeconds}초 전';
+  } else if (difference.inMinutes < 60) {
+    return '${difference.inMinutes}분 전';
+  } else if (difference.inHours < 24) {
+    return '${difference.inHours}시간 전';
+  } else if (difference.inDays < 7) {
+    return '${difference.inDays}일 전';
+  } else if (difference.inDays < 30) {
+    return '${(difference.inDays / 7).floor()}주 전';
+  } else if (difference.inDays < 365) {
+    return '${(difference.inDays / 30).floor()}개월 전';
+  } else {
+    return '${(difference.inDays / 365).floor()}년 전';
+  }
+}

--- a/lib/features/user/repositories/entities/user_entity.dart
+++ b/lib/features/user/repositories/entities/user_entity.dart
@@ -40,11 +40,15 @@ class UserEntity {
   /// 앱 리뷰 가능 여부
   final bool isReviewRequestAvailable;
 
+  /// 로그인 횟수
+  final int? loginCount;
+
   const UserEntity({
     required this.uid,
     this.profileImgUrl,
     this.nickname,
     this.email,
+    this.loginCount,
     required this.signUpDate,
     required this.completedInterviewCount,
     required this.isReviewRequestAvailable,
@@ -61,6 +65,7 @@ class UserEntity {
     required UserBox box,
   }) {
     return UserEntity(
+      loginCount: model.loginCount ?? 0,
       uid: model.uid,
       nickname: model.nickname,
       profileImgUrl: model.profileImgUrl,

--- a/lib/presentation/pages/home/widgets/practical_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/practical_interview_card.dart
@@ -37,7 +37,8 @@ class PracticalInterviewCard extends ConsumerWidget with HomeState, HomeEvent {
                     ),
                   ),
                 ),
-                GestureDetector(
+                BounceTapper(
+                  highlightColor: Colors.transparent,
                   onTap: () {
                     routeToTopicSelectPage(
                       context,

--- a/lib/presentation/pages/home/widgets/single_topic_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/single_topic_interview_card.dart
@@ -37,7 +37,8 @@ class SingleTopicInterviewCard extends ConsumerWidget
                     style: AppTextStyle.headline2,
                   ),
                 ),
-                GestureDetector(
+                BounceTapper(
+                  highlightColor: Colors.transparent,
                   onTap: () {
                     routeToTopicSelectPage(
                       context,

--- a/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.dart
@@ -103,7 +103,7 @@ class InterviewProgressState extends _$InterviewProgressState {
     unawaited(noti.SlackNotificationService.sendNotification(
         type: SlackNotificationType.event,
         message:
-            '면접을 완료했어요!(${ref.read(selectedChatRoomProvider).passOrFail.name})'));
+            '면접을 완료했어요!(결과:${ref.read(selectedChatRoomProvider).passOrFail.name})'));
     unawaited(FirebaseAnalytics.instance.logEvent(
       name: 'Interview Completed',
       parameters: {
@@ -145,6 +145,9 @@ class InterviewProgressState extends _$InterviewProgressState {
 
               if (await inAppReview.isAvailable()) {
                 unawaited(inAppReview.requestReview());
+                unawaited(noti.SlackNotificationService.sendNotification(
+                    type: SlackNotificationType.event,
+                    message: '유저에게 앱 리뷰를 요청했어요!'));
               }
             }
           }

--- a/lib/presentation/pages/interview/chat_list/chat_list_page.dart
+++ b/lib/presentation/pages/interview/chat_list/chat_list_page.dart
@@ -48,6 +48,7 @@ class ChatListPage extends BasePage with ChatListState, ChatListEvent {
       error: (e, _) => const Text('채팅 6 불러오지 못하였습니다'),
       loading: () {
         return ListView.builder(
+          physics: const NeverScrollableScrollPhysics(),
           itemCount: 5,
           itemBuilder: (context, index) {
             return ChatRoomItemView.createSkeleton();

--- a/lib/presentation/pages/interview/chat_list/local_widgets/chat_room_item_view.dart
+++ b/lib/presentation/pages/interview/chat_list/local_widgets/chat_room_item_view.dart
@@ -1,3 +1,4 @@
+import 'package:bounce_tapper/bounce_tapper.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';

--- a/lib/presentation/pages/interview/question_count_select/question_count_select_event.dart
+++ b/lib/presentation/pages/interview/question_count_select/question_count_select_event.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/core/constants/slack_notification_type.enum.dart';
+import 'package:techtalk/core/services/slack_notification_service.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/topic/topic.dart';
 import 'package:techtalk/presentation/pages/interview/question_count_select/providers/selected_question_count_provider.dart';
@@ -17,17 +21,24 @@ mixin class QuestionCountSelectEvent {
     // 페이지 이동 및 채팅방 정보 조회 후 제거한다.
     await EasyLoading.show();
 
+    final questionCount = ref.read(selectedQuestionCountProvider) +
+        SelectedQuestionCount.defaultPlusCount;
+
     final room = ChatRoomEntity.random(
       type: type,
       topics: topics,
-      questionCount: ref.read(selectedQuestionCountProvider) +
-          SelectedQuestionCount.defaultPlusCount,
+      questionCount: questionCount,
     );
 
     final route = ChatPageRoute(roomId: room.id, type: room.type);
 
     route.updateArg(room: room);
     route.go(ref.context);
+
+    unawaited(SlackNotificationService.sendNotification(
+        type: SlackNotificationType.event,
+        message:
+            '면접을 새롭게 시작했어요 (${topics.map((e) => e.text)}/개수$questionCount)'));
 
     await EasyLoading.dismiss();
   }

--- a/lib/presentation/pages/interview/topic_select/interview_topic_select_page.dart
+++ b/lib/presentation/pages/interview/topic_select/interview_topic_select_page.dart
@@ -128,6 +128,7 @@ class _NextButton extends ConsumerWidget
       padding: const EdgeInsets.symmetric(horizontal: 16),
       height: 56,
       child: BounceTapper(
+        enable: isStepBtnActivate(ref),
         child: FilledButton(
           onPressed: isStepBtnActivate(ref)
               ? () {

--- a/lib/presentation/pages/interview/topic_select/interview_topic_select_page.dart
+++ b/lib/presentation/pages/interview/topic_select/interview_topic_select_page.dart
@@ -128,11 +128,12 @@ class _NextButton extends ConsumerWidget
       padding: const EdgeInsets.symmetric(horizontal: 16),
       height: 56,
       child: BounceTapper(
-        onTap: () {
-          routeToQuestionCountSelect(ref);
-        },
         child: FilledButton(
-          onPressed: () {},
+          onPressed: isStepBtnActivate(ref)
+              ? () {
+                  routeToQuestionCountSelect(ref);
+                }
+              : null,
           child: Center(
             child: Text(tr(LocaleKeys.common_next)),
           ),

--- a/lib/presentation/pages/my_info/my_page/my_page_event.dart
+++ b/lib/presentation/pages/my_info/my_page/my_page_event.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
@@ -6,7 +8,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:in_app_review/in_app_review.dart';
 import 'package:techtalk/app/localization/locale_keys.g.dart';
 import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/core/constants/slack_notification_type.enum.dart';
 import 'package:techtalk/core/index.dart';
+import 'package:techtalk/core/services/slack_notification_service.dart' as noti;
 import 'package:techtalk/features/user/user.dart';
 import 'package:techtalk/presentation/pages/study/learning/providers/study_answer_blur_provider.dart';
 import 'package:techtalk/presentation/pages/wrong_answer_note/providers/wrong_answer_blur_provider.dart';
@@ -59,6 +63,7 @@ mixin class MyPageEvent {
         rightBtnContent: tr(LocaleKeys.myInfo_others_logout),
         showContentImg: false,
         onRightBtnClicked: () {
+          unawaited(noti.SlackNotificationService.sendNotification(type: SlackNotificationType.logOut));
           _clearKeepAliveModules(ref);
           const SignInRoute().go(ref.context);
         },
@@ -101,6 +106,8 @@ mixin class MyPageEvent {
           await EasyLoading.show();
           final response = await resignUserInfoUseCase
               .call(ref.read(userInfoProvider).requireValue!);
+          unawaited(noti.SlackNotificationService.sendNotification(
+              type: SlackNotificationType.withdraw));
           response.fold(
             onSuccess: (_) {
               _clearKeepAliveModules(ref);

--- a/lib/presentation/pages/sign_in/sign_in_event.dart
+++ b/lib/presentation/pages/sign_in/sign_in_event.dart
@@ -4,6 +4,8 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/core/constants/slack_notification_type.enum.dart';
+import 'package:techtalk/core/services/slack_notification_service.dart' as noti;
 import 'package:techtalk/features/auth/repositories/entities/user_account_provider.enum.dart';
 import 'package:techtalk/presentation/providers/user/user_auth_provider.dart';
 import 'package:techtalk/presentation/providers/user/user_info_provider.dart';
@@ -20,6 +22,7 @@ mixin class SignInEvent {
           unawaited(FirebaseAnalytics.instance
               .logLogin(loginMethod: accountProvider.name));
           const MainRoute().go(ref.context);
+          unawaited(noti.SlackNotificationService.sendNotification(type: SlackNotificationType.login, targetUserInfo: userData));
         } else {
           unawaited(FirebaseAnalytics.instance
               .logSignUp(signUpMethod: accountProvider.name));

--- a/lib/presentation/pages/sign_up/events/sign_up_event.dart
+++ b/lib/presentation/pages/sign_up/events/sign_up_event.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer';
 
 import 'package:easy_localization/easy_localization.dart';
@@ -7,7 +8,9 @@ import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/localization/locale_keys.g.dart';
 import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/core/constants/slack_notification_type.enum.dart';
 import 'package:techtalk/core/index.dart';
+import 'package:techtalk/core/services/slack_notification_service.dart';
 import 'package:techtalk/features/tech_set/tech_set.dart';
 import 'package:techtalk/features/user/user.dart';
 import 'package:techtalk/presentation/pages/my_info/job_group_setting/provider/selected_job_groups_provider.dart';
@@ -22,7 +25,9 @@ import 'package:techtalk/presentation/providers/user/user_auth_provider.dart';
 import 'package:techtalk/presentation/providers/user/user_info_provider.dart';
 
 part 'job_group_step_event.p.dart';
+
 part 'nickname_step_event.p.dart';
+
 part 'skill_step_event.p.dart';
 
 mixin class SignUpEvent {
@@ -56,7 +61,13 @@ mixin class SignUpEvent {
       );
 
       await ref.read(userInfoProvider.notifier).createData(userData).then(
-        (_) {
+        (_) async {
+          unawaited(
+            SlackNotificationService.sendNotification(
+              targetUserInfo: userData,
+              type: SlackNotificationType.signUp,
+            ),
+          );
           const MainRoute().go(ref.context);
         },
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct main"
     description:
       name: bounce_tapper
-      sha256: "834b4a28cb885bfe637f1783aca1f04b7b809ae60500c5f9f349527436fb43eb"
+      sha256: "9da0a4c73b4477559c9e40c41ab5ab8b0ef26d8de1cecc6d41c5087f9640cb6a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.6"
   build:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.5+20
+version: 1.0.8+23
 
 environment:
   sdk: ">=3.0.6 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.10+25
+version: 1.0.9+25
 
 environment:
   sdk: ">=3.0.6 <4.0.0"
@@ -29,7 +29,7 @@ dependencies:
   smooth_page_indicator: ^1.1.0 # pageview 인디케이터
   flutter_animate: ^4.2.0+1 # 간편 애니메이션 메소드 지원
   cached_network_image: ^3.3.0 # 네트워크 이미지 캐싱
-  bounce_tapper: ^1.0.4
+  bounce_tapper: ^1.0.6
   local_hero: ^0.3.0
   defer_pointer: ^0.0.2 # Overflow 영역에도 터치를 보장할 수 있도록 도와주는 패키지
   gap: ^3.0.1 # 간격 위젯

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none"
 
-version: 1.0.5+20
+version: 1.0.10+25
 
 environment:
   sdk: ">=3.0.6 <4.0.0"


### PR DESCRIPTION
## 📝 변경 내용

아래와 같은 오류가 발생. 

- 홈 > 실전형 면접 카드
   플러스 버튼 클릭시 주제 선택 페이지를 스킵하고 채팅 기록 페이지로 이동
- 면접 주제 선택 페이지
면접 주제를 선택하지 않았음에도 다음 버튼 클릭 가능 (이대로 진행하면 에러 발생)

bounceTapper 패키지 자체의 결함을 수정하고 생략된 로직 추가

<br/>


## 👥 리뷰어
@yundal8755 , @Yellowtoast 

<br>

## 📌 기타 사항
https://github.com/MakeFrog/TechTalk/pull/129 
제가 bounceTapper 모듈을 적용하는 작업을 진행하면서 기존에 로직을 삭제하거나 사이드 이펙트를 고려하지못해서 발생된 이슈입니다. 

빠르게 확인해 주셔서 감사합니다!
<br>
