### PR TITLE
Feat: [영상상세페이지] 유튜브 api 데이터 세팅 로직 구현

### DIFF
--- a/lib/app/di/app_binding.dart
+++ b/lib/app/di/app_binding.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import 'package:techtalk/app/di/modules/auth_di.dart';
 import 'package:techtalk/app/di/modules/chat_di.dart';
+import 'package:techtalk/app/di/modules/contents_di.dart';
 import 'package:techtalk/app/di/modules/system_di.dart';
 import 'package:techtalk/app/di/modules/tech_set_di.dart';
 import 'package:techtalk/app/di/modules/topic_di.dart';
@@ -41,6 +42,7 @@ final class AppBinder {
       JobDependencyInjection(),
       ChatDependencyInject(),
       TopicDependencyInjection(),
+      ContentsDependencyInjection(),
     ]) {
       di.init();
     }

--- a/lib/app/di/modules/contents_di.dart
+++ b/lib/app/di/modules/contents_di.dart
@@ -1,0 +1,34 @@
+import 'package:techtalk/app/di/app_binding.dart';
+import 'package:techtalk/app/di/feature_di_interface.dart';
+import 'package:techtalk/features/contents/contents.dart';
+
+final class ContentsDependencyInjection extends FeatureDependencyInjection {
+  @override
+  void dataSources() {
+    // locator
+    //   ..registerLazySingleton<TopicLocalDataSource>(
+    //     () => TopicLocalDataSourceImpl(AppLocal.qnasBox),
+    //   )
+    //   ..registerLazySingleton<TopicRemoteDataSource>(
+    //     TopicRemoteDataSourceImpl.new,
+    //   );
+  }
+
+  /// TODO: 추후에 다른 repository 추가 예정
+  @override
+  void repositories() {
+    locator.registerLazySingleton<ContentsRepository>(
+      () => ContentsRepositoryImpl(),
+    );
+  }
+
+  @override
+  void useCases() {
+    locator
+      ..registerFactory(
+        () => GetYoutubeVideoDataUseCase(
+          contentsRepository,
+        ),
+      );
+  }
+}

--- a/lib/app/di/modules/topic_di.dart
+++ b/lib/app/di/modules/topic_di.dart
@@ -1,12 +1,7 @@
 import 'package:techtalk/app/di/app_binding.dart';
 import 'package:techtalk/app/di/feature_di_interface.dart';
 import 'package:techtalk/core/modules/local/app_local.dart';
-import 'package:techtalk/features/topic/data_source/local/topic_local_data_source_impl.dart';
-import 'package:techtalk/features/topic/data_source/remote/topic_remote_data_source_impl.dart';
-import 'package:techtalk/features/topic/repositories/topic_repository_impl.dart';
 import 'package:techtalk/features/topic/topic.dart';
-import 'package:techtalk/features/topic/usecases/get_wrong_answers_use_case.dart';
-import 'package:techtalk/features/topic/usecases/update_wrong_answer_use_case.dart';
 
 final class TopicDependencyInjection extends FeatureDependencyInjection {
   @override

--- a/lib/app/environment/flavor.dart
+++ b/lib/app/environment/flavor.dart
@@ -1,4 +1,5 @@
 import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:dart_openai/dart_openai.dart' as forWhisper;
 import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -7,7 +8,6 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:techtalk/app/di/app_binding.dart';
 import 'package:techtalk/app/environment/environment.enum.dart';
 import 'package:techtalk/core/modules/local/app_local.dart';
-import 'package:dart_openai/dart_openai.dart' as forWhisper;
 
 class Flavor {
   Flavor._();
@@ -43,25 +43,19 @@ class Flavor {
       options: option,
     );
 
-    OpenAI.instance.build(
-      token: env.openApiKey,
-      baseOption: HttpSetup(receiveTimeout: const Duration(seconds: 10), connectTimeout: const Duration(seconds: 10)),
-      enableLog: true,
-    );
-
     /// 채팅 면접에서 사용되는 OepnAI SK
     OpenAI.instance.build(
       token: env.openApiKey,
       baseOption: HttpSetup(
-          receiveTimeout: const Duration(seconds: 10),
-          connectTimeout: const Duration(seconds: 10)),
+        receiveTimeout: const Duration(seconds: 10),
+        connectTimeout: const Duration(seconds: 10),
+      ),
       enableLog: true,
     );
 
     /// whisper 모델을 제공하는 OpenAI SDK
     forWhisper.OpenAI.apiKey = env.openApiKey;
     forWhisper.OpenAI.requestsTimeOut = const Duration(seconds: 12);
-
 
     /// 앱 DI 실행
     await AppBinder.init();

--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -3,8 +3,10 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/features/chat/chat.dart';
-import 'package:techtalk/features/chat/repositories/enums/interview_type.enum.dart';
+import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
+import 'package:techtalk/presentation/pages/contents/contents_detail_page.dart';
+import 'package:techtalk/presentation/pages/contents/contents_main_page.dart';
 import 'package:techtalk/presentation/pages/interview/chat/chat_page.dart';
 import 'package:techtalk/presentation/pages/interview/chat_list/chat_list_page.dart';
 import 'package:techtalk/presentation/pages/interview/chat_list/providers/chat_list_route_arg.dart';
@@ -154,6 +156,14 @@ class SignUpRoute extends GoRouteData {
       path: StudyRoute.path,
       name: StudyRoute.name,
     ),
+    TypedGoRoute<ContentsMainRoute>(
+      path: ContentsMainRoute.path,
+      name: ContentsMainRoute.name,
+    ),
+    TypedGoRoute<ContentsDetailRoute>(
+      path: ContentsDetailRoute.path,
+      name: ContentsDetailRoute.name,
+    ),
     TypedGoRoute<WrongAnswerRoute>(
       path: WrongAnswerRoute.path,
       name: WrongAnswerRoute.name,
@@ -211,6 +221,36 @@ class StudyRoute extends GoRouteData {
   }
 }
 
+class ContentsMainRoute extends GoRouteData {
+  ContentsMainRoute();
+
+  static const String path = 'contents';
+  static const String name = 'contents';
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const ContentsMainPage();
+  }
+}
+
+class ContentsDetailRoute extends GoRouteData {
+  ContentsDetailRoute(this.$extra) : contentsId = $extra.contentsId;
+
+  static const String path = 'contents-detail/:contentsId';
+  static const String name = 'contents-detail';
+
+  final ContentsOverviewEntity $extra;
+
+  final String contentsId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return ContentsDetailPage(
+      overview: $extra,
+    );
+  }
+}
+
 class WrongAnswerRoute extends GoRouteData {
   const WrongAnswerRoute(this.index);
 
@@ -259,8 +299,7 @@ class QuestionCountSelectPageRoute extends GoRouteData {
   }
 
   /// NOTE: $extra 이슈로 직접 업데이트
-  void updateArg(
-      {required InterviewType type, required List<TopicEntity> topics}) {
+  void updateArg({required InterviewType type, required List<TopicEntity> topics}) {
     arg = (topics: topics, type: type);
   }
 }
@@ -312,11 +351,7 @@ class ChatListRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    arg = (
-      topic: StoredTopics.getByIdOrNull(topicId),
-      interviewType: type,
-      chatRooms: $extra
-    );
+    arg = (topic: StoredTopics.getByIdOrNull(topicId), interviewType: type, chatRooms: $extra);
     return ChatListPage();
   }
 }
@@ -341,8 +376,7 @@ class ChatPageRoute extends GoRouteData {
         var end = Offset.zero;
         var curve = Curves.ease;
 
-        var tween =
-            Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+        var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
 
         return SlideTransition(
           position: animation.drive(tween),

--- a/lib/app/router/router.g.dart
+++ b/lib/app/router/router.g.dart
@@ -120,6 +120,16 @@ RouteBase get $mainRoute => GoRouteData.$route(
           factory: $StudyRouteExtension._fromState,
         ),
         GoRouteData.$route(
+          path: 'contents',
+          name: 'contents',
+          factory: $ContentsMainRouteExtension._fromState,
+        ),
+        GoRouteData.$route(
+          path: 'contents-detail/:contentsId',
+          name: 'contents-detail',
+          factory: $ContentsDetailRouteExtension._fromState,
+        ),
+        GoRouteData.$route(
           path: 'wrong-answer/:index',
           name: 'wrong answer',
           factory: $WrongAnswerRouteExtension._fromState,
@@ -264,6 +274,46 @@ extension $StudyRouteExtension on StudyRoute {
 
   String get location => GoRouteData.$location(
         '/study/${Uri.encodeComponent(topicId)}',
+      );
+
+  void go(BuildContext context) => context.go(location, extra: $extra);
+
+  Future<T?> push<T>(BuildContext context) =>
+      context.push<T>(location, extra: $extra);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location, extra: $extra);
+
+  void replace(BuildContext context) =>
+      context.replace(location, extra: $extra);
+}
+
+extension $ContentsMainRouteExtension on ContentsMainRoute {
+  static ContentsMainRoute _fromState(GoRouterState state) =>
+      ContentsMainRoute();
+
+  String get location => GoRouteData.$location(
+        '/contents',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $ContentsDetailRouteExtension on ContentsDetailRoute {
+  static ContentsDetailRoute _fromState(GoRouterState state) =>
+      ContentsDetailRoute(
+        state.extra as ContentsOverviewEntity,
+      );
+
+  String get location => GoRouteData.$location(
+        '/contents-detail/${Uri.encodeComponent(contentsId)}',
       );
 
   void go(BuildContext context) => context.go(location, extra: $extra);

--- a/lib/core/helper/int_extension.dart
+++ b/lib/core/helper/int_extension.dart
@@ -1,0 +1,66 @@
+import 'package:techtalk/app/localization/localization_enum.dart';
+
+extension IntExtensions on int {
+  ///
+  /// 숫자의 포맷팅을 짧게 해주는 함수
+  /// 조회수와 같은 용도에 적합
+  ///
+  String formatViewCount(Localization locale) {
+    if (locale == Localization.kr) {
+      return _formatKorean(this, '회');
+    } else {
+      return _formatEnglish(this, 'views');
+    }
+  }
+
+  ///
+  /// 숫자의 포맷팅을 짧게 해주는 함수
+  /// 다양한 용도에 사용 가능
+  ///
+  String formatCount(Localization locale, {String suffix = ''}) {
+    if (locale == Localization.kr) {
+      return _formatKorean(this, suffix);
+    } else {
+      return _formatEnglish(this, suffix);
+    }
+  }
+
+  String _formatKorean(int count, String suffixText) {
+    if (count < 100) {
+      return '$count$suffixText';
+    } else if (count < 1000) {
+      double result = count / 100;
+      return '${_trimDecimal(result)}백$suffixText';
+    } else if (count < 10000) {
+      double result = count / 1000;
+      return '${_trimDecimal(result)}천$suffixText';
+    } else if (count < 100000000) {
+      // 1억 미만
+      double result = count / 10000;
+      return '${_trimDecimal(result)}만$suffixText';
+    } else {
+      double result = count / 100000000;
+      return '${_trimDecimal(result)}억$suffixText';
+    }
+  }
+
+  String _formatEnglish(int count, String suffixText) {
+    if (count < 1000) {
+      return '$count$suffixText';
+    } else if (count < 1000000) {
+      double result = count / 1000;
+      return '${_trimDecimal(result)}K$suffixText';
+    } else if (count < 1000000000) {
+      double result = count / 1000000;
+      return '${_trimDecimal(result)}M$suffixText';
+    } else {
+      double result = count / 1000000000;
+      return '${_trimDecimal(result)}B$suffixText';
+    }
+  }
+
+  String _trimDecimal(double number) {
+    // 소수점 첫째 자리까지 표시, 필요 없으면 정수로 표시
+    return number == number.roundToDouble() ? number.toInt().toString() : number.toStringAsFixed(1);
+  }
+}

--- a/lib/core/modules/exceptions/custom_exception.dart
+++ b/lib/core/modules/exceptions/custom_exception.dart
@@ -25,18 +25,15 @@ class AlreadyExistNicknameException extends CustomException {
 }
 
 class NoTopicQuestionException extends CustomException {
-  const NoTopicQuestionException(String topic)
-      : super('200002', '$topic 주제의 면접 질문이 없습니다.');
+  const NoTopicQuestionException(String topic) : super('200002', '$topic 주제의 면접 질문이 없습니다.');
 }
 
 class NoTopicException extends CustomException {
-  const NoTopicException(String topic)
-      : super('200003', '$topic 주제 데이터가 없습니다.');
+  const NoTopicException(String topic) : super('200003', '$topic 주제 데이터가 없습니다.');
 }
 
 class NoQnAsException extends CustomException {
-  const NoQnAsException(String topic)
-      : super('200004', '$topic 주제의 면접 문답 데이터가 없습니다.');
+  const NoQnAsException(String topic) : super('200004', '$topic 주제의 면접 문답 데이터가 없습니다.');
 }
 
 class TopicInitialFailed extends CustomException {
@@ -44,18 +41,15 @@ class TopicInitialFailed extends CustomException {
 }
 
 class ChatMessageFetchedFailedException extends CustomException {
-  const ChatMessageFetchedFailedException()
-      : super('300001', '채팅 기록을 가져오는데 실패하였습니다.');
+  const ChatMessageFetchedFailedException() : super('300001', '채팅 기록을 가져오는데 실패하였습니다.');
 }
 
 class ChatRoomsFetchedFailedException extends CustomException {
-  const ChatRoomsFetchedFailedException()
-      : super('300002', '채팅방 목록을 가져오는데 실패하였습니다.');
+  const ChatRoomsFetchedFailedException() : super('300002', '채팅방 목록을 가져오는데 실패하였습니다.');
 }
 
 class ChatRoomCreationFailedException extends CustomException {
-  const ChatRoomCreationFailedException()
-      : super('300003', '채팅방을 생성하는데 실패하였습니다.');
+  const ChatRoomCreationFailedException() : super('300003', '채팅방을 생성하는데 실패하였습니다.');
 }
 
 class ChatReportFailed extends CustomException {
@@ -63,28 +57,23 @@ class ChatReportFailed extends CustomException {
 }
 
 class NoInterviewQuestionException extends CustomException {
-  const NoInterviewQuestionException(String topic)
-      : super('000002', '$topic 주제의 면접 질문이 없습니다.');
+  const NoInterviewQuestionException(String topic) : super('000002', '$topic 주제의 면접 질문이 없습니다.');
 }
 
 class NoInterviewTopicException extends CustomException {
-  const NoInterviewTopicException(String topic)
-      : super('000003', '$topic 주제 데이터가 없습니다.');
+  const NoInterviewTopicException(String topic) : super('000003', '$topic 주제 데이터가 없습니다.');
 }
 
 class FetchSkillsFailedException extends CustomException {
-  const FetchSkillsFailedException()
-      : super('000004', '테크 스킬 목록을 불러오는데 실패하였습니다');
+  const FetchSkillsFailedException() : super('000004', '테크 스킬 목록을 불러오는데 실패하였습니다');
 }
 
 class WrongAnswerUpdateFailedException extends CustomException {
-  const WrongAnswerUpdateFailedException()
-      : super('000005', '오답노트 정보를 업데이트하는데 실패하였습니다.');
+  const WrongAnswerUpdateFailedException() : super('000005', '오답노트 정보를 업데이트하는데 실패하였습니다.');
 }
 
 class WrongAnswerFetchFailedException extends CustomException {
-  const WrongAnswerFetchFailedException()
-      : super('000006', '오답노트 목록을 가져오는데 실패하였습니다.');
+  const WrongAnswerFetchFailedException() : super('000006', '오답노트 목록을 가져오는데 실패하였습니다.');
 }
 
 class ImgStoreFailedException extends CustomException {
@@ -96,13 +85,11 @@ class MappingFailedException extends CustomException {
 }
 
 class VersionInfoFetchedFailedException extends CustomException {
-  const VersionInfoFetchedFailedException()
-      : super('500001', '앱 버전 정보를 가져오는데 실패하였습니다.');
+  const VersionInfoFetchedFailedException() : super('500001', '앱 버전 정보를 가져오는데 실패하였습니다.');
 }
 
 class SystemNotAvailableWithNotification extends CustomException {
-  const SystemNotAvailableWithNotification()
-      : super('500002', '시스템 사용불가 / 공지 메세지');
+  const SystemNotAvailableWithNotification() : super('500002', '시스템 사용불가 / 공지 메세지');
 }
 
 class SystemOnMaintenanceException extends CustomException {
@@ -119,4 +106,8 @@ class SystemNetworkUnstable extends CustomException {
 
 class SystemSomethingWrongException extends CustomException {
   const SystemSomethingWrongException() : super('500007', '알 수 없는 오류');
+}
+
+class FetchYoutubeContentsException extends CustomException {
+  const FetchYoutubeContentsException() : super('500008', '영상 정보 데이터를 불러오는 데에 실패하였습니다.');
 }

--- a/lib/features/contents/contents.dart
+++ b/lib/features/contents/contents.dart
@@ -1,0 +1,17 @@
+import 'package:techtalk/app/di/app_binding.dart';
+import 'package:techtalk/features/contents/repositories/contents_repository.dart';
+import 'package:techtalk/features/contents/usecases/get_youtube_video_data_use_case.dart';
+
+export 'contents.dart';
+export 'repositories/contents_repository.dart';
+export 'repositories/contents_repository_impl.dart';
+export 'repositories/entities/contents_author_entity.dart';
+export 'repositories/entities/contents_detail_entity.dart';
+export 'repositories/entities/contents_overview_entity.dart';
+export 'repositories/entities/paragraph_entity.dart';
+export 'repositories/entities/summary_entity.dart';
+export 'repositories/entities/youtube_video_data_entity.dart';
+export 'usecases/get_youtube_video_data_use_case.dart';
+
+final contentsRepository = locator<ContentsRepository>();
+final getYoutubeVideoDataUseCase = locator<GetYoutubeVideoDataUseCase>();

--- a/lib/features/contents/repositories/contents_repository_impl.dart
+++ b/lib/features/contents/repositories/contents_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:techtalk/core/modules/error_handling/result.dart';
 import 'package:techtalk/core/modules/exceptions/custom_exception.dart';
 import 'package:techtalk/features/contents/repositories/contents_repository.dart';
@@ -8,17 +10,24 @@ class ContentsRepositoryImpl implements ContentsRepository {
   @override
   Future<Result<YouTubeVideoDataEntity>> getYoutubeVideoData(String videoId) async {
     try {
-      final video = await YoutubeExplode().videos.get(videoId);
-
-      final channel = await YoutubeExplode().channels.get(video.channelId);
+      final ys = YoutubeExplode();
+      final video = await ys.videos.get(videoId);
+      final channel = await ys.channels.get(video.channelId);
 
       return Result.success(
-        YouTubeVideoDataEntity(videoInfo: video, channelInfo: channel),
+        YouTubeVideoDataEntity(
+          id: video.id.value,
+          url: video.url,
+          title: video.title,
+          thumnailSet: video.thumbnails,
+          engagement: video.engagement,
+          channelInfo: channel,
+        ),
       );
     } on Exception catch (e) {
-      // log('getTopicQnas : $e');
+      log('getYoutubeVideoData : $e');
       return Result.failure(
-        NoTopicQuestionException(videoId),
+        const FetchYoutubeContentsException(),
       );
     }
   }

--- a/lib/features/contents/repositories/entities/contents_detail_entity.dart
+++ b/lib/features/contents/repositories/entities/contents_detail_entity.dart
@@ -16,6 +16,10 @@ class ContentsDetailEntity {
   /// 컨텐츠 타이틀
   final String title;
 
+  /// NOTE: 저자 정보인데, 유튜브 api에서 channel 정보와 겹친다.
+  /// 어떻게 처리해야할지 고민 필요
+  // final ContentsAuthorEntity author;
+
   /// 관련 기술 스킬
   final Set<SkillEntity> relatedSkills;
 
@@ -38,6 +42,7 @@ class ContentsDetailEntity {
     required this.id,
     required this.contentsId,
     required this.title,
+    // required this.author,
     required this.relatedSkills,
     required this.relatedJobs,
     required this.contentsLanguage,

--- a/lib/features/contents/repositories/entities/contents_overview_entity.dart
+++ b/lib/features/contents/repositories/entities/contents_overview_entity.dart
@@ -71,8 +71,6 @@ class VideoContentsOverviewEntity implements ContentsOverviewEntity {
   @override
   final Set<JobGroup> relatedJobs;
 
-  final int? viewCount;
-
   final Duration videoDuration;
 
   VideoContentsOverviewEntity({
@@ -84,7 +82,6 @@ class VideoContentsOverviewEntity implements ContentsOverviewEntity {
     required this.relatedJobs,
     required this.relatedSkills,
     required this.videoDuration,
-    this.viewCount,
     this.qnaNum = 0,
   });
 }

--- a/lib/features/contents/repositories/entities/youtube_video_data_entity.dart
+++ b/lib/features/contents/repositories/entities/youtube_video_data_entity.dart
@@ -1,22 +1,30 @@
+import 'package:techtalk/app/localization/localization_enum.dart';
+import 'package:techtalk/core/helper/int_extension.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
 /// YouTube API에서 가져온 비디오 데이터
 class YouTubeVideoDataEntity {
-  final String videoId;
-  final String videoUrl;
-  final String videoTitle;
+  final String id;
+  final String url;
+  final String title;
+  final ThumbnailSet thumnailSet;
   final Engagement engagement;
   final Channel channelInfo;
   final Duration? duration;
   final DateTime? uploadDate;
 
   YouTubeVideoDataEntity({
-    required this.videoId,
-    required this.videoUrl,
-    required this.videoTitle,
+    required this.id,
+    required this.url,
+    required this.title,
+    required this.thumnailSet,
     required this.engagement,
     required this.channelInfo,
     this.duration,
     this.uploadDate,
   });
+
+  String get viewCountStr => engagement.viewCount.formatViewCount(Localization.kr);
+
+  String get likeCountStr => (engagement.likeCount ?? 0).formatCount(Localization.kr);
 }

--- a/lib/features/contents/usecases/get_youtube_video_data_use_case.dart
+++ b/lib/features/contents/usecases/get_youtube_video_data_use_case.dart
@@ -1,0 +1,14 @@
+import 'dart:async';
+
+import 'package:techtalk/core/index.dart';
+import 'package:techtalk/features/contents/repositories/contents_repository.dart';
+import 'package:techtalk/features/contents/repositories/entities/youtube_video_data_entity.dart';
+
+final class GetYoutubeVideoDataUseCase extends BaseUseCase<String, Result<YouTubeVideoDataEntity>> {
+  GetYoutubeVideoDataUseCase(this._repository);
+
+  final ContentsRepository _repository;
+
+  @override
+  Future<Result<YouTubeVideoDataEntity>> call(String request) => _repository.getYoutubeVideoData(request);
+}

--- a/lib/presentation/pages/contents/constants/contents_detail_tab_type.enum.dart
+++ b/lib/presentation/pages/contents/constants/contents_detail_tab_type.enum.dart
@@ -1,0 +1,8 @@
+enum ContentsDetailTabType {
+  summary('요약'),
+  questions('면접질문');
+
+  final String displayStr;
+
+  const ContentsDetailTabType(this.displayStr);
+}

--- a/lib/presentation/pages/contents/contents_detail_event.dart
+++ b/lib/presentation/pages/contents/contents_detail_event.dart
@@ -1,0 +1,11 @@
+import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
+import 'package:techtalk/features/user/repositories/entities/user_entity.dart';
+import 'package:techtalk/presentation/pages/contents/contents_detail_page.dart';
+
+mixin class ContentsDetailEvent {
+  tabChanged(TabType tabType) {}
+
+  onTapAuthorProfile(ContentsAuthorEntity author) {}
+
+  onTapUploaderProfile(UserEntity uploader) {}
+}

--- a/lib/presentation/pages/contents/contents_detail_event.dart
+++ b/lib/presentation/pages/contents/contents_detail_event.dart
@@ -1,9 +1,9 @@
 import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
 import 'package:techtalk/features/user/repositories/entities/user_entity.dart';
-import 'package:techtalk/presentation/pages/contents/contents_detail_page.dart';
+import 'package:techtalk/presentation/pages/contents/constants/contents_detail_tab_type.enum.dart';
 
 mixin class ContentsDetailEvent {
-  tabChanged(TabType tabType) {}
+  tabChanged(ContentsDetailTabType tabType) {}
 
   onTapAuthorProfile(ContentsAuthorEntity author) {}
 

--- a/lib/presentation/pages/contents/contents_detail_page.dart
+++ b/lib/presentation/pages/contents/contents_detail_page.dart
@@ -5,22 +5,13 @@ import 'package:techtalk/app/style/app_color.dart';
 import 'package:techtalk/app/style/app_text_style.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 import 'package:techtalk/presentation/pages/contents/contents_detail_event.dart';
-import 'package:techtalk/presentation/pages/contents/providers/youtube_video_data_provider.dart';
+import 'package:techtalk/presentation/pages/contents/contents_detail_state.dart';
 import 'package:techtalk/presentation/widgets/base/base_page.dart';
 import 'package:techtalk/presentation/widgets/common/box/async_skeleton_widget_builder.dart';
 import 'package:techtalk/presentation/widgets/common/common.dart';
 
-enum TabType {
-  summary('요약'),
-  questions('면접질문');
-
-  final String displayStr;
-
-  const TabType(this.displayStr);
-}
-
 /// 유튜브 컨텐츠 상세 페이지
-class ContentsDetailPage extends BasePage with ContentsDetailEvent {
+class ContentsDetailPage extends BasePage with ContentsDetailEvent, ContentsDetailState {
   const ContentsDetailPage({super.key, required this.overview});
 
   final ContentsOverviewEntity overview;
@@ -29,13 +20,11 @@ class ContentsDetailPage extends BasePage with ContentsDetailEvent {
   Widget buildPage(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
 
-    final videoData = ref.watch(youtubeVideoDataProvider(overview.contentsId));
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         AsyncSkeletonWidgetBuilder(
-          asyncValue: videoData,
+          asyncValue: youtubeVideoDataAsync(ref, overview.contentsId),
           skeletonBuilder: (p0) => SizedBox(
             height: 210,
             width: double.infinity,
@@ -63,7 +52,7 @@ class ContentsDetailPage extends BasePage with ContentsDetailEvent {
             runSpacing: 5,
             children: [
               AsyncSkeletonWidgetBuilder(
-                asyncValue: videoData,
+                asyncValue: youtubeVideoDataAsync(ref, overview.contentsId),
                 skeletonBuilder: (p0) => Text(
                   overview.contentsTitle,
                   style: AppTextStyle.headline3,
@@ -74,7 +63,7 @@ class ContentsDetailPage extends BasePage with ContentsDetailEvent {
                 ),
               ),
               AsyncSkeletonWidgetBuilder(
-                asyncValue: videoData,
+                asyncValue: youtubeVideoDataAsync(ref, overview.contentsId),
                 skeletonBuilder: (_) => const SkeletonBox(
                   height: 20,
                 ),
@@ -100,7 +89,7 @@ class ContentsDetailPage extends BasePage with ContentsDetailEvent {
                 ),
               ),
               AsyncSkeletonWidgetBuilder(
-                asyncValue: videoData,
+                asyncValue: youtubeVideoDataAsync(ref, overview.contentsId),
                 skeletonBuilder: (p0) => const SkeletonBox(
                   height: 20,
                 ),

--- a/lib/presentation/pages/contents/contents_detail_page.dart
+++ b/lib/presentation/pages/contents/contents_detail_page.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/app/style/app_color.dart';
+import 'package:techtalk/app/style/app_text_style.dart';
+import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
+import 'package:techtalk/presentation/pages/contents/contents_detail_event.dart';
+import 'package:techtalk/presentation/pages/contents/providers/youtube_video_data_provider.dart';
+import 'package:techtalk/presentation/widgets/base/base_page.dart';
+import 'package:techtalk/presentation/widgets/common/box/async_skeleton_widget_builder.dart';
+import 'package:techtalk/presentation/widgets/common/common.dart';
+
+enum TabType {
+  summary('요약'),
+  questions('면접질문');
+
+  final String displayStr;
+
+  const TabType(this.displayStr);
+}
+
+/// 유튜브 컨텐츠 상세 페이지
+class ContentsDetailPage extends BasePage with ContentsDetailEvent {
+  const ContentsDetailPage({super.key, required this.overview});
+
+  final ContentsOverviewEntity overview;
+
+  @override
+  Widget buildPage(BuildContext context, WidgetRef ref) {
+    useAutomaticKeepAlive();
+
+    final videoData = ref.watch(youtubeVideoDataProvider(overview.contentsId));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AsyncSkeletonWidgetBuilder(
+          asyncValue: videoData,
+          skeletonBuilder: (p0) => SizedBox(
+            height: 210,
+            width: double.infinity,
+            child: Image.network(
+              overview.thumbnailImgUrl,
+              fit: BoxFit.cover,
+            ),
+          ),
+          dataBuilder: (context, data) => SizedBox(
+            height: 210,
+            width: double.infinity,
+            // TODO: 이미지 캐싱 기능 구현
+            child: Image.network(
+              data.thumnailSet.highResUrl,
+              fit: BoxFit.cover,
+            ),
+          ),
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 15),
+          child: Wrap(
+            runSpacing: 5,
+            children: [
+              AsyncSkeletonWidgetBuilder(
+                asyncValue: videoData,
+                skeletonBuilder: (p0) => Text(
+                  overview.contentsTitle,
+                  style: AppTextStyle.headline3,
+                ),
+                dataBuilder: (context, data) => Text(
+                  data.title,
+                  style: AppTextStyle.headline3,
+                ),
+              ),
+              AsyncSkeletonWidgetBuilder(
+                asyncValue: videoData,
+                skeletonBuilder: (_) => const SkeletonBox(
+                  height: 20,
+                ),
+                dataBuilder: (context, data) => Row(
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(
+                          Icons.thumb_up,
+                          size: 15,
+                        ),
+                        const SizedBox(
+                          width: 2,
+                        ),
+                        Text(data.likeCountStr),
+                      ],
+                    ),
+                    const SizedBox(
+                      width: 9,
+                    ),
+                    Text('조회수 ${data.viewCountStr}'),
+                  ],
+                ),
+              ),
+              AsyncSkeletonWidgetBuilder(
+                asyncValue: videoData,
+                skeletonBuilder: (p0) => const SkeletonBox(
+                  height: 20,
+                ),
+                dataBuilder: (context, data) => Row(
+                  children: [
+                    CircleAvatar(
+                      backgroundImage: NetworkImage(data.channelInfo.logoUrl),
+                      radius: 15,
+                    ),
+                    Text(
+                      data.channelInfo.title,
+                    ),
+                    Text(
+                      (data.channelInfo.subscribersCount ?? '').toString(),
+                    ),
+                  ],
+                ),
+              ),
+              Wrap(
+                spacing: 8.0,
+                children: overview.relatedSkills
+                    .map(
+                      (skill) => Chip(label: Text(skill.name)),
+                    )
+                    .toList(),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  bool get canPop => false;
+
+  @override
+  Color? get screenBackgroundColor => AppColor.of.white;
+
+  @override
+  Color? get unSafeAreaColor => AppColor.of.white;
+
+  @override
+  PreferredSizeWidget? buildAppBar(BuildContext context, WidgetRef ref) => AppBar(
+        leading: const AppBackButton(),
+        titleSpacing: 0,
+      );
+}

--- a/lib/presentation/pages/contents/contents_detail_state.dart
+++ b/lib/presentation/pages/contents/contents_detail_state.dart
@@ -1,0 +1,11 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/features/contents/repositories/entities/youtube_video_data_entity.dart';
+import 'package:techtalk/presentation/pages/contents/providers/youtube_video_data_provider.dart';
+
+mixin class ContentsDetailState {
+  ///
+  /// 유튜브 api에서 불러오는 비디오 관련 데이터
+  ///
+  AsyncValue<YouTubeVideoDataEntity> youtubeVideoDataAsync(WidgetRef ref, String contentsId) =>
+      ref.watch(youtubeVideoDataProvider(contentsId));
+}

--- a/lib/presentation/pages/contents/contents_main_event.dart
+++ b/lib/presentation/pages/contents/contents_main_event.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
+
+mixin class ContentsMainEvent {
+  void routeToChatPage(
+    BuildContext context, {
+    required ContentsOverviewEntity overview,
+  }) {
+    final route = ContentsDetailRoute(overview);
+    route.push(context);
+  }
+}

--- a/lib/presentation/pages/contents/contents_main_page.dart
+++ b/lib/presentation/pages/contents/contents_main_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/core/index.dart';
+import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
+import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
+import 'package:techtalk/features/tech_set/tech_set.dart';
+import 'package:techtalk/presentation/pages/contents/contents_main_event.dart';
+import 'package:techtalk/presentation/widgets/base/base_page.dart';
+
+class ContentsMainPage extends BasePage with ContentsMainEvent {
+  const ContentsMainPage({super.key});
+
+  @override
+  Widget buildPage(BuildContext context, WidgetRef ref) {
+    // TODO: 컨텐츠 Overview 리스트로 띄워주는 로직 및 UI 구현
+    return Scaffold(
+      body: GestureDetector(
+        onTap: () => routeToChatPage(
+          context,
+          overview: VideoContentsOverviewEntity(
+            id: 'zI1NzcV4Ef0',
+            contentsId: 'zI1NzcV4Ef0',
+            thumbnailImgUrl:
+                'https://images.wondershare.kr/filmora/images/2021-images/seo/make-youtu-Thumbnail-use-filmora3.jpg',
+            contentsTitle: '[배고파_마카오_EP.04] 밥에 감자튀김? 이런 건 나도 처음 보는데...?',
+            author: ContentsAuthorEntity(id: 'id', name: '백종원'),
+            relatedJobs: {JobGroup.ANDROID_DEVELOPER},
+            relatedSkills: {SkillEntity(id: 'android', name: 'Android')},
+            videoDuration: Duration(minutes: 20),
+          ),
+        ),
+        child: Center(
+          child: Container(
+            width: 200,
+            height: 200,
+            color: Colors.lightGreen,
+            child: Text('콘텐츠 디테일 페이지로 이동'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/contents/providers/youtube_video_data_provider.dart
+++ b/lib/presentation/pages/contents/providers/youtube_video_data_provider.dart
@@ -1,0 +1,21 @@
+import 'dart:developer';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:techtalk/features/contents/contents.dart';
+
+part 'youtube_video_data_provider.g.dart';
+
+@riverpod
+class YoutubeVideoData extends _$YoutubeVideoData {
+  @override
+  Future<YouTubeVideoDataEntity> build(String videoId) async {
+    final result = await getYoutubeVideoDataUseCase.call(videoId);
+    return result.fold(
+      onSuccess: (data) => data,
+      onFailure: (e) {
+        log(e.toString());
+        throw e;
+      },
+    );
+  }
+}

--- a/lib/presentation/pages/contents/providers/youtube_video_data_provider.g.dart
+++ b/lib/presentation/pages/contents/providers/youtube_video_data_provider.g.dart
@@ -1,0 +1,176 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'youtube_video_data_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$youtubeVideoDataHash() => r'79f5ce6f488244abf59bb714ffc8999e47117601';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$YoutubeVideoData
+    extends BuildlessAutoDisposeAsyncNotifier<YouTubeVideoDataEntity> {
+  late final String videoId;
+
+  FutureOr<YouTubeVideoDataEntity> build(
+    String videoId,
+  );
+}
+
+/// See also [YoutubeVideoData].
+@ProviderFor(YoutubeVideoData)
+const youtubeVideoDataProvider = YoutubeVideoDataFamily();
+
+/// See also [YoutubeVideoData].
+class YoutubeVideoDataFamily
+    extends Family<AsyncValue<YouTubeVideoDataEntity>> {
+  /// See also [YoutubeVideoData].
+  const YoutubeVideoDataFamily();
+
+  /// See also [YoutubeVideoData].
+  YoutubeVideoDataProvider call(
+    String videoId,
+  ) {
+    return YoutubeVideoDataProvider(
+      videoId,
+    );
+  }
+
+  @override
+  YoutubeVideoDataProvider getProviderOverride(
+    covariant YoutubeVideoDataProvider provider,
+  ) {
+    return call(
+      provider.videoId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'youtubeVideoDataProvider';
+}
+
+/// See also [YoutubeVideoData].
+class YoutubeVideoDataProvider extends AutoDisposeAsyncNotifierProviderImpl<
+    YoutubeVideoData, YouTubeVideoDataEntity> {
+  /// See also [YoutubeVideoData].
+  YoutubeVideoDataProvider(
+    String videoId,
+  ) : this._internal(
+          () => YoutubeVideoData()..videoId = videoId,
+          from: youtubeVideoDataProvider,
+          name: r'youtubeVideoDataProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$youtubeVideoDataHash,
+          dependencies: YoutubeVideoDataFamily._dependencies,
+          allTransitiveDependencies:
+              YoutubeVideoDataFamily._allTransitiveDependencies,
+          videoId: videoId,
+        );
+
+  YoutubeVideoDataProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.videoId,
+  }) : super.internal();
+
+  final String videoId;
+
+  @override
+  FutureOr<YouTubeVideoDataEntity> runNotifierBuild(
+    covariant YoutubeVideoData notifier,
+  ) {
+    return notifier.build(
+      videoId,
+    );
+  }
+
+  @override
+  Override overrideWith(YoutubeVideoData Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: YoutubeVideoDataProvider._internal(
+        () => create()..videoId = videoId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        videoId: videoId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<YoutubeVideoData,
+      YouTubeVideoDataEntity> createElement() {
+    return _YoutubeVideoDataProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is YoutubeVideoDataProvider && other.videoId == videoId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, videoId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin YoutubeVideoDataRef
+    on AutoDisposeAsyncNotifierProviderRef<YouTubeVideoDataEntity> {
+  /// The parameter `videoId` of this provider.
+  String get videoId;
+}
+
+class _YoutubeVideoDataProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<YoutubeVideoData,
+        YouTubeVideoDataEntity> with YoutubeVideoDataRef {
+  _YoutubeVideoDataProviderElement(super.provider);
+
+  @override
+  String get videoId => (origin as YoutubeVideoDataProvider).videoId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/main/main_page.dart
+++ b/lib/presentation/pages/main/main_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/style/app_color.dart';
 import 'package:techtalk/app/style/app_text_style.dart';
+import 'package:techtalk/presentation/pages/contents/contents_main_page.dart';
 import 'package:techtalk/presentation/pages/home/home_page.dart';
 import 'package:techtalk/presentation/pages/main/main_event.dart';
 import 'package:techtalk/presentation/pages/my_info/my_page/my_page.dart';
@@ -27,6 +28,9 @@ class MainPage extends BasePage with MainEvent {
       ),
       StudyTopicSelectionPage(
         key: ValueKey(MainNavigationTab.study),
+      ),
+      ContentsMainPage(
+        key: ValueKey(MainNavigationTab.contents),
       ),
       WrongAnswerNotePage(
         key: ValueKey(MainNavigationTab.note),

--- a/lib/presentation/providers/main_bottom_navigation_provider.dart
+++ b/lib/presentation/providers/main_bottom_navigation_provider.dart
@@ -6,6 +6,7 @@ part 'main_bottom_navigation_provider.g.dart';
 enum MainNavigationTab {
   home('gnb.home', Assets.iconsHome),
   study('gnb.learning', Assets.iconsStudy),
+  contents('gnb.learning', Assets.iconsStudy),
   note('gnb.mistakeNote', Assets.iconsNote),
   myInfo('gnb.myInfo', Assets.iconsUser);
 

--- a/lib/presentation/widgets/common/box/async_skeleton_widget_builder.dart
+++ b/lib/presentation/widgets/common/box/async_skeleton_widget_builder.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'skeleton_box.dart';
+
+/// 비동기 동안 skeleton 위젯을 자연스럽게 띄워주는 위젯
+class AsyncSkeletonWidgetBuilder<T> extends StatelessWidget {
+  final AsyncValue<T> asyncValue;
+  final Widget Function(BuildContext, T) dataBuilder;
+  final Widget Function(BuildContext)? skeletonBuilder;
+  final Widget Function(BuildContext, Object, StackTrace)? errorBuilder;
+
+  const AsyncSkeletonWidgetBuilder({
+    Key? key,
+    required this.asyncValue,
+    required this.dataBuilder,
+    this.skeletonBuilder,
+    this.errorBuilder,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 300),
+      child: asyncValue.when(
+        data: (data) => dataBuilder(context, data),
+        loading: () => skeletonBuilder?.call(context) ?? _defaultSkeleton(),
+        error: (error, stack) => errorBuilder?.call(context, error, stack) ?? _defaultError(context, error),
+      ),
+    );
+  }
+
+  Widget _defaultSkeleton() {
+    // 기본 스켈레톤 UI 예시 (단일 SkeletonBox)
+    return const SkeletonBox(
+      height: 20,
+    );
+  }
+
+  Widget _defaultError(BuildContext context, Object error) {
+    return const SkeletonBox(
+      height: 20,
+    );
+  }
+}


### PR DESCRIPTION
## 📝 변경 내용
* 영상 메인, 상세 라우트 세팅
* 영상 상세 페이지에서 유튜브 api정보 불러오는 기능 구현

<br>

## 📌 참고 사항
* UI가 온전히 완성되어있지 않고, youtube api를 사용하여 뿌려주는 부분만 임시로 구현되어 있습니다.
* 해당 부분 빠르게 피드백 받은 후에, 영상 메인화면과 상세에 사용되는 데이터 firebase 세팅 관련하여 논의 예정


<br>

## 👥 리뷰어
* @Xim-ya @yundal8755 


