### PR TITLE
[공통] 화면 Widget에서 전달 받은 인자(argument)를 효율적으로 관리하기 위한 모듈 개발 (ArgumentHolder)

### DIFF
--- a/lib/presentation/widgets/base/argument_holder_context_extension.dart
+++ b/lib/presentation/widgets/base/argument_holder_context_extension.dart
@@ -1,0 +1,16 @@
+part of 'route_argument.dart';
+
+///
+/// BuildContext에 argument 값을 쉽게 가져올 수 있는 확장 메서드를 추가
+/// ArgumentHolder 위젯에서 전달된 값을 가져와 타입에 맞게 반환
+///
+extension ArgumentHolderContextExt on BuildContext {
+  T getArgument<T>() {
+    try {
+      final argument = ArgumentHolder.maybeOf(this)?.argument;
+      return argument;
+    } catch (e) {
+      throw Exception('잘못된 인자값 입니다 : $e');
+    }
+  }
+}

--- a/lib/presentation/widgets/base/base_page.dart
+++ b/lib/presentation/widgets/base/base_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/style/app_color.dart';
+import 'package:techtalk/presentation/widgets/base/route_argument.dart';
 
 ///
 /// 앱의 화면 페이지를 생성하는 유틸리티 클래스
@@ -71,16 +72,19 @@ abstract class BasePage extends HookConsumerWidget {
   }
 
   Widget _buildScaffold(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      extendBody: extendBodyBehindAppBar,
-      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-      appBar: buildAppBar(context, ref),
-      body: buildPage(context, ref),
-      backgroundColor: screenBackgroundColor,
-      bottomNavigationBar: buildBottomNavigationBar(context),
-      bottomSheet: buildBottomSheet(ref),
-      floatingActionButtonLocation: floatingActionButtonLocation,
-      floatingActionButton: buildFloatingActionButton(ref),
+    return ArgumentHolder(
+      argument: argument,
+      child: Scaffold(
+        extendBody: extendBodyBehindAppBar,
+        resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+        appBar: buildAppBar(context, ref),
+        body: buildPage(context, ref),
+        backgroundColor: screenBackgroundColor,
+        bottomNavigationBar: buildBottomNavigationBar(context),
+        bottomSheet: buildBottomSheet(ref),
+        floatingActionButtonLocation: floatingActionButtonLocation,
+        floatingActionButton: buildFloatingActionButton(ref),
+      ),
     );
   }
 
@@ -142,6 +146,10 @@ abstract class BasePage extends HookConsumerWidget {
   /// 화면 클릭 시 자동으로 포커스를 해제할지 여부를 설정
   @protected
   bool get preventAutoUnfocus => false;
+
+  /// 전달받은 argument
+  @protected
+  dynamic get argument => null;
 
   /// 앱이 활성화된 상태로 돌아올 때 호출
   @protected

--- a/lib/presentation/widgets/base/route_argument.dart
+++ b/lib/presentation/widgets/base/route_argument.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/cupertino.dart';
+
+part 'argument_holder_context_extension.dart';
+
+///
+/// 화면에 데이터를 전달하기 위한 InheritedWidget 클래스
+/// 주어진 context를 통해 전달받은 argument 값을 접근할 수 있도록 제공
+///
+class ArgumentHolder extends InheritedWidget {
+  final dynamic argument;
+
+  const ArgumentHolder({
+    required this.argument,
+    super.key,
+    required super.child,
+  });
+
+  static ArgumentHolder? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<ArgumentHolder>();
+  }
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
+}


### PR DESCRIPTION
## 무엇이 문제였나요?
화면에서 이전 화면으로부터 전달받은 argument를 하위 위젯으로 전달할 때, 매번 해당 argument를 일일이 넘겨주어야 하는 Prop Drilling 이슈가 발생함.

예를 들어, 화면이 여러 개의 커스텀 위젯으로 구성되어 있고, 각 커스텀 위젯이 argument를 참조해야 하는 경우, 아래 코드처럼 각 위젯에 일일이 argument를 넘겨주어야 하는 번거로움이 존재할 수 있음.

```dart
class HomePage extends BasePage {  
  const HomePage(this.argument, {super.key});  
  
  final SomeArgument passedId; // <-- argument!!

  @override  
  Widget buildPage(BuildContext context, WidgetRef ref) {  
    return Column(  
      children: [  
        Header(passedId),  // <-- argument 넘겨주기 1
        CardView(passedId), // <-- argument 넘겨주기 2
        CustomListView(passedId),   // <-- argument 넘겨주기 3
        Footer(passedId)  // <-- argument 넘겨주기 4 😱
      ],  
    );  
  }  
}
```

특히 위젯의 depth가 깊어질수록 더 복잡해짐.

## 어떻게 해결했나요?
Inherited 위젯을 사용하여, 위젯의 상위에서 전달된 argument를 context를 통해 접근할 수 있도록 기본 화면 유틸리티 모듈(BasePage)에 필요한 로직을 추가하였음. 이를 통해 코드를 더 깔끔하고 간결하게 유지할 수 있음.

> 사용 방법은 아래와 같습니다

### argument 초기화

```dart
class HomePage extends BasePage {  
  const HomePage(this.argument, {super.key});  
  
  final String passedId;  
  
  @override   
  get argument => passedId;  // <-- 1️⃣ 전달받은 argument를 getter 메서드에 리턴 
  
  @override  
  Widget buildPage(BuildContext context, WidgetRef ref) {  
    return Column(  
      children: [  
        Header(),  
        CardView(),  
        CustomListView(),  
        Footer()  
      ],  
    );  
  }  
}
```

### argument 접근

```dart
class Header extends StatelessWidget {  
  const Header({super.key});  
  
  @override  
  Widget build(BuildContext context) {  
    final argument = context.getArgument<String>();   // 2️⃣ <-- context를 통해 argument 접근 
    // or context.getArgument()
    return ...;  
  }  
}
```

### event, state mixin 로직과 함께 사용 시
```dart
mixin class HomEvent {  
  void onBtnTapped(WidgetRef ref) {  
    final targetId = ref.context.getArgument<String>(); // <-- argument를 여러 번 넘겨주지 않아도 됨  
    ref.read(someProvider.notifier).updateInfo();  
  }  
}
```


## Base 모듈 코드

### Argument Holder
```dart
///
/// 화면에 데이터를 전달하기 위한 InheritedWidget 클래스
/// 주어진 context를 통해 전달받은 argument 값을 접근할 수 있도록 제공
///
class ArgumentHolder extends InheritedWidget {
  final dynamic argument;

  const ArgumentHolder({
    required this.argument,
    super.key,
    required super.child,
  });

  static ArgumentHolder? maybeOf(BuildContext context) {
    return context.dependOnInheritedWidgetOfExactType<ArgumentHolder>();
  }

  @override
  bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
}
```

### extension
```dart
///
/// BuildContext에 argument 값을 쉽게 가져올 수 있는 확장 메서드를 추가
/// ArgumentHolder 위젯에서 전달된 값을 가져와 타입에 맞게 반환
///
extension ArgumentHolderContextExt on BuildContext {
  T getArgument<T>() {
    try {
      final argument = ArgumentHolder.maybeOf(this)?.argument;
      return argument;
    } catch (e) {
      throw Exception('잘못된 인자값 입니다 : $e');
    }
  }
}

```