### PR TITLE
[채팅 면접] 이력서 면접 질문 생성 프롬프트 테스트

### DIFF
--- a/lib/features/chat/use_cases/set_ai_resume_question_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_resume_question_use_case.dart
@@ -1,0 +1,61 @@
+import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:techtalk/core/index.dart';
+
+/// AI를 사용하여 이력서/포트폴리오 데이터를 분석하고 면접을 위한 Qna 엔티티 리스트를 생성하는 UseCase
+/// String이 아닌 JSON을 반환해야 하지만 임시로
+class SetAiResumeQuestionUseCase
+    extends BaseUseCase<GetResumeParam, Result<String>> {
+  @override
+  Future<Result<String>> call(GetResumeParam param) async {
+    try {
+      // OpenAI에 요청을 보낼 ChatCompleteText 객체를 생성합니다.
+      final chatRequest = ChatCompleteText(
+        messages: _createResumeAnalysisPrompt(param),
+        maxToken: 300,
+        model: Gpt4ChatModel(),
+        temperature: 0.5,
+        user: FirebaseAuth.instance.currentUser!.uid,
+      );
+
+      // OpenAI API 단일 응답 호출
+      final ChatCTResponse? response =
+          await OpenAI.instance.onChatCompletion(request: chatRequest);
+
+      // 응답 데이터에서 String으로 추출
+      if (response?.choices == null || response!.choices.isEmpty) {
+        throw Exception("Invalid response from OpenAI");
+      }
+      final rawContent = response.choices.first.message?.content ?? '';
+
+      return Result.success(rawContent);
+    } catch (e) {
+      return Result.failure(Exception(e.toString()));
+    }
+  }
+
+  List<Map<String, String>> _createResumeAnalysisPrompt(GetResumeParam param) {
+    final promptContent = '''
+  당신은 이력서/포트폴리오 분석을 도와주는 전문 AI 면접관입니다.
+  아래는 지원자의 이력서 내용입니다:
+
+  "${param.resumeOrPortfolioContent}"
+
+  이 내용을 바탕으로 지원자에게 면접 시 물어볼 수 있는 적합한 질문 5개를 만들어주세요.
+  각 질문은 간결하고 명확해야 합니다.
+  ''';
+
+    return [
+      {
+        'role': 'user',
+        'content': promptContent,
+      },
+    ];
+  }
+}
+
+/// 파라미터
+typedef GetResumeParam = ({
+  bool isFile,
+  String? resumeOrPortfolioContent,
+});

--- a/lib/features/chat/use_cases/set_ai_resume_question_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_resume_question_use_case.dart
@@ -1,17 +1,18 @@
+import 'dart:convert';
 import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:techtalk/core/index.dart';
+import 'package:techtalk/features/topic/repositories/entities/qna_entity.dart';
+import 'package:uuid/uuid.dart';
 
-/// AI를 사용하여 이력서/포트폴리오 데이터를 분석하고 면접을 위한 Qna 엔티티 리스트를 생성하는 UseCase
-/// String이 아닌 JSON을 반환해야 하지만 임시로
 class SetAiResumeQuestionUseCase
-    extends BaseUseCase<GetResumeParam, Result<String>> {
+    extends BaseUseCase<GetResumeParam, Result<List<QnaEntity>>> {
   @override
-  Future<Result<String>> call(GetResumeParam param) async {
+  Future<Result<List<QnaEntity>>> call(GetResumeParam request) async {
     try {
-      // OpenAI에 요청을 보낼 ChatCompleteText 객체를 생성합니다.
+      // OpenAI에 요청을 보낼 ChatCompleteText 객체 생성
       final chatRequest = ChatCompleteText(
-        messages: _createResumeAnalysisPrompt(param),
+        messages: _createResumeAnalysisPrompt(request),
         maxToken: 300,
         model: Gpt4ChatModel(),
         temperature: 0.5,
@@ -22,40 +23,84 @@ class SetAiResumeQuestionUseCase
       final ChatCTResponse? response =
           await OpenAI.instance.onChatCompletion(request: chatRequest);
 
-      // 응답 데이터에서 String으로 추출
+      // 응답 데이터가 유효한지 확인
       if (response?.choices == null || response!.choices.isEmpty) {
-        throw Exception("Invalid response from OpenAI");
+        throw Exception("OpenAI 응답이 유효하지 않습니다.");
       }
+
+      // OpenAI 응답을 JSON으로 파싱
       final rawContent = response.choices.first.message?.content ?? '';
 
-      return Result.success(rawContent);
+      final List<String> parsedQuestions = _parseQuestions(rawContent);
+
+      // QnaEntity 리스트로 변환
+      final List<QnaEntity> qnaEntities = parsedQuestions
+          .map(
+            (question) => QnaEntity(
+              id: _generateUniqueId(),
+              question: question,
+              answers: [],
+            ),
+          )
+          .toList();
+
+      return Result.success(qnaEntities);
     } catch (e) {
       return Result.failure(Exception(e.toString()));
     }
   }
 
-  List<Map<String, String>> _createResumeAnalysisPrompt(GetResumeParam param) {
+  List<Map<String, dynamic>> _createResumeAnalysisPrompt(GetResumeParam param) {
     final promptContent = '''
-  당신은 이력서/포트폴리오 분석을 도와주는 전문 AI 면접관입니다.
-  아래는 지원자의 이력서 내용입니다:
+당신은 이력서/포트폴리오 분석을 도와주는 면접관이며, 유저는 지원자입니다.
+아래는 지원자의 이력서 내용입니다:
 
-  "${param.resumeOrPortfolioContent}"
+"${param.resumeOrPortfolioContent}"
 
-  이 내용을 바탕으로 지원자에게 면접 시 물어볼 수 있는 적합한 질문 5개를 만들어주세요.
-  각 질문은 간결하고 명확해야 합니다.
-  ''';
+이 내용을 바탕으로 지원자의 기술적 역량(하드 스킬)과 대인관계, 문제 해결 능력 등 비기술적 역량(소프트 스킬)을 구분하여 면접에서 물어볼 수 있는 질문을 3~8개 만들어주세요.
+응답은 반드시 JSON 형식의 리스트로 작성해주세요. 예:
 
-    return [
-      {
-        'role': 'user',
-        'content': promptContent,
-      },
+["질문1", "질문2", "질문3", "질문4", "질문5"]
+
+질문은 아래의 예시 기준으로 작성해주세요:
+- (하드스킬) Flutter 개발 경험과 관련된 구체적인 문제 해결 사례를 물어볼 수 있는 질문
+- (소프트스킬) 팀 협업 과정에서 어려움을 극복한 경험에 대한 질문
+
+응답은 명확하고 직관적이어야 하며, JSON 형식을 엄격히 준수해야 합니다.
+''';
+
+    final messages = [
+      Messages(role: Role.system, content: promptContent).toJson(),
+      Messages(role: Role.user, content: promptContent).toJson(),
     ];
+    return messages;
+  }
+
+  List<String> _parseQuestions(String rawContent) {
+    try {
+      // JSON 파싱
+      final parsedJson = jsonDecode(rawContent);
+
+      // JSON이 리스트 형태인지 확인
+      if (parsedJson is List<dynamic>) {
+        final questions = parsedJson.map((item) => item.toString()).toList();
+        return questions;
+      } else {
+        throw Exception('JSON 형식이 올바르지 않습니다.');
+      }
+    } catch (e) {
+      throw Exception('OpenAI 응답 파싱에 실패했습니다: $e');
+    }
+  }
+
+  String _generateUniqueId() {
+    const uuid = Uuid();
+    return uuid.v4();
   }
 }
 
 /// 파라미터
 typedef GetResumeParam = ({
   bool isFile,
-  String? resumeOrPortfolioContent,
+  String resumeOrPortfolioContent,
 });

--- a/lib/presentation/pages/home/home_event.dart
+++ b/lib/presentation/pages/home/home_event.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/router/router.dart';
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/features/chat/chat.dart';
+import 'package:techtalk/features/chat/use_cases/set_ai_resume_question_use_case.dart';
 import 'package:techtalk/presentation/pages/interview/chat_list/providers/practical_chat_room_list_provider.dart';
 import 'package:techtalk/presentation/providers/main_bottom_navigation_provider.dart';
 import 'package:techtalk/presentation/providers/system/notification_status_provider.dart';
@@ -18,6 +19,39 @@ import 'package:techtalk/presentation/providers/user/user_topics_provider.dart';
 part 'internal_home_event.p.dart';
 
 mixin class HomeEvent {
+  ///
+  /// [SetAiResumeQuestionUseCase]를 호출하여 결과를 출력하는 테스트 메서드
+  /// 테스트를 위한 임시 코드
+  ///
+  Future<void> testSetAiResumeQuestionUseCase({
+    required bool isFile,
+    String? resumeOrPortfolioContent,
+  }) async {
+    final useCase = SetAiResumeQuestionUseCase();
+
+    // 입력 파라미터 생성
+    final param = (
+      isFile: isFile,
+      resumeOrPortfolioContent: resumeOrPortfolioContent,
+    );
+
+    print('===== GPT에 응답을 요청했습니다 잠시만 기다려주세요 =====');
+
+    try {
+      final result = await useCase.call(param);
+      result.fold(
+        onSuccess: (qnaEntities) {
+          print("AI 분석 성공: $qnaEntities");
+        },
+        onFailure: (error) {
+          print("AI 분석 실패: $error");
+        },
+      );
+    } catch (e) {
+      log("UseCase 실행 중 예외 발생: $e");
+    }
+  }
+
   ///
   /// 실전 면접 카드(전체 영역)가 클릭 되었을 때
   /// 실전 면접 기록 여부에 따라 라우팅을 다르게 진행

--- a/lib/presentation/pages/home/home_event.dart
+++ b/lib/presentation/pages/home/home_event.dart
@@ -25,7 +25,7 @@ mixin class HomeEvent {
   ///
   Future<void> testSetAiResumeQuestionUseCase({
     required bool isFile,
-    String? resumeOrPortfolioContent,
+    required String resumeOrPortfolioContent,
   }) async {
     final useCase = SetAiResumeQuestionUseCase();
 

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -1,23 +1,16 @@
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:permission_handler/permission_handler.dart';
-import 'package:rxdart/subjects.dart';
-import 'package:techtalk/app/localization/app_locale.dart';
-import 'package:techtalk/app/localization/localization_enum.dart';
 import 'package:techtalk/app/style/app_color.dart';
 import 'package:techtalk/core/index.dart';
-import 'package:techtalk/features/chat/chat.dart';
-import 'package:techtalk/features/topic/topic.dart';
 import 'package:techtalk/presentation/pages/home/home_event.dart';
 import 'package:techtalk/presentation/pages/home/widgets/cheer_up_message_card.dart';
 import 'package:techtalk/presentation/pages/home/widgets/home_state.dart';
 import 'package:techtalk/presentation/pages/home/widgets/practical_interview_card.dart';
 import 'package:techtalk/presentation/pages/home/widgets/single_topic_interview_card.dart';
+import 'package:techtalk/presentation/pages/home/widgets/test_resume_interview_card.dart';
 import 'package:techtalk/presentation/widgets/base/base_page.dart';
 import 'package:techtalk/presentation/widgets/base/controller_holder.dart';
 import 'package:techtalk/presentation/widgets/common/common.dart';
@@ -47,6 +40,8 @@ class HomePage extends BasePage with HomeState, HomeEvent {
             padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
             children: const [
               CheerUpMessageCard(),
+              Gap(16),
+              TestResumeInterviewCard(),
               Gap(16),
               PracticalInterviewCard(),
               Gap(16),

--- a/lib/presentation/pages/home/widgets/test_resume_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/test_resume_interview_card.dart
@@ -1,0 +1,80 @@
+import 'package:bounce_tapper/bounce_tapper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/app/style/index.dart';
+import 'package:techtalk/core/index.dart';
+import 'package:techtalk/presentation/pages/home/home_event.dart';
+import 'package:techtalk/presentation/pages/home/widgets/home_state.dart';
+
+class TestResumeInterviewCard extends ConsumerWidget with HomeState, HomeEvent {
+  const TestResumeInterviewCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 임시 프롬프팅 파라미터
+    const String resumeOrPortfolioContent = '''
+저는 5년 이상의 Flutter 개발 경험이 있으며, riverpod와 provider를 활용한 상태 관리에 능숙합니다. GoRouter를 사용하여 복잡한 내비게이션 구조를 구현한 경험이 있고, 3개의 Flutter 앱을 성공적으로 출시하여 앱 스토어에서 긍정적인 평가를 받았습니다.
+
+또한, RESTful API와 GraphQL을 활용한 백엔드 연동 경험이 있으며, Firebase를 이용한 인증 및 데이터베이스 관리에 익숙합니다. 팀 협업을 위한 Git 및 CI/CD 파이프라인 구축 경험도 가지고 있습니다.
+
+UI/UX 디자인에도 관심이 많아 Material Design과 Cupertino 디자인 가이드를 준수하여 사용자 친화적인 인터페이스를 구현할 수 있습니다. 문제 해결 능력이 뛰어나며, 새로운 기술을 학습하고 적용하는 데 적극적입니다.
+''';
+
+    return BounceTapper(
+      onTap: () {
+        testSetAiResumeQuestionUseCase(
+          isFile: false,
+          resumeOrPortfolioContent: resumeOrPortfolioContent,
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(24, 12, 0, 12),
+        decoration: BoxDecoration(
+          color: AppColor.of.brand1,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Text(
+                    '이력서 프롬프트 실험 버튼\n(Print 출력)',
+                    style: AppTextStyle.headline2.copyWith(
+                      color: AppColor.of.brand3,
+                    ),
+                  ),
+                ),
+                BounceTapper(
+                  highlightColor: Colors.transparent,
+                  onTap: () {
+                    /// 임시 로직
+                    // routeToChatPage(
+                    //   ref,
+                    //   type: InterviewType.resume,
+                    //   topics: [],
+                    // );
+                  },
+                  child: SvgPicture.asset(Assets.iconsRoundBlueCircle),
+                ),
+              ],
+            ),
+            if (!(user(ref)?.hasPracticalInterviewRecord ?? false))
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12, right: 24),
+                child: Text(
+                  '이력서를 첨부하여 면접을 시작해보세요!',
+                  style: AppTextStyle.body1.copyWith(
+                    color: AppColor.of.gray3,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📝 변경 내용
이력서 면접 질문 생성 프롬프팅 명세에 알맞게 use_case를 구현하고 테스트를 해보았습니다.
미완료 항목은 11월 27일 수요일까지 완료할 예정입니다.

https://github.com/MakeFrog/TechTalk/issues/153
**구현시 고려 사항**
- [ ]  이력서/포트폴리오 정보를 파일 혹은 텍스트 형태로 프롬프트에 제공할 수 있어야 한다.
- [x]  프롬프팅 usecase의 리턴 값은 Qna엔티티의 리스트가 되어야 한다.
- [x]  프롬프팅의 결과로 json을 받되, 클래스 형식(Qna 엔티티)으로 변환되어야 한다.
- [x]  단순 정보 생성이므로 단일 응답값 리턴으로 구현된다.

**확인 필요 사항**
- [ ]  이력서/포트폴리오를 파일 형태로 api에 전송 가능한지 여부 확인
- [ ]  파일 형태로 제공 가능하다면, 사용되는 토큰의 양 체크 필요함. (요금체크)


<br>

## 👥 리뷰어
@Xim-ya @Yellowtoast 

<br>

## 📌 기타 사항
- 프롬프팅 usecase의 리턴 값은 아직은 String입니다. Qna엔티티의 리스트를 리턴 값으로 받도록 수정할 예정입니다.
- 현재 코드에서는 텍스트 형태의 이력서/포트폴리오만 처리 가능 (파일 처리 로직은 구현되지 않았습니다)
- 하단 사진처럼 현재 프롬프팅 테스트를 하면서 500 에러가 자주 발생합니다. 정확한 문제 원인을 발견하게 되면 공유드리겠습니다.
![image](https://github.com/user-attachments/assets/d91cb105-a825-4821-adf0-510e2ae755bb)





<br>
