### PR TITLE
[이력서 면접 > 채팅] 이력서 기반 면접 질문 프로세스 호환 작업   

### DIFF
--- a/lib/app/router/router.g.dart
+++ b/lib/app/router/router.g.dart
@@ -177,8 +177,8 @@ extension $InterviewTopicSelectRouteExtension on InterviewTopicSelectRoute {
 }
 
 const _$InterviewTypeEnumMap = {
-  InterviewType.singleTopic: 'single-topic',
-  InterviewType.practical: 'practical',
+  InterviewType.commonSingleTopic: 'single-topic',
+  InterviewType.commonPracticalTopic: 'practical',
   InterviewType.resume: 'resume',
 };
 

--- a/lib/app/router/router.g.dart
+++ b/lib/app/router/router.g.dart
@@ -177,8 +177,8 @@ extension $InterviewTopicSelectRouteExtension on InterviewTopicSelectRoute {
 }
 
 const _$InterviewTypeEnumMap = {
-  InterviewType.commonSingleTopic: 'single-topic',
-  InterviewType.commonPracticalTopic: 'practical',
+  InterviewType.commonSingleTopic: 'common-single-topic',
+  InterviewType.commonPracticalTopic: 'common-practical-topic',
   InterviewType.resume: 'resume',
 };
 

--- a/lib/features/chat/data_source/remote/chat_remote_data_source_impl.dart
+++ b/lib/features/chat/data_source/remote/chat_remote_data_source_impl.dart
@@ -24,13 +24,14 @@ final class ChatRemoteDataSourceImpl implements ChatRemoteDataSource {
     TopicEntity? topic,
   ]) async {
     final snapshot = switch (type) {
-      InterviewType.singleTopic => await FirestoreChatRoomRef.collection()
+      InterviewType.commonSingleTopic => await FirestoreChatRoomRef.collection()
           .where(FirestoreChatRoomRef.typeField, isEqualTo: type.name)
           .where(FirestoreChatRoomRef.topicIdsField, arrayContains: topic!.id)
           .get(),
-      InterviewType.practical => await FirestoreChatRoomRef.collection()
-          .where(FirestoreChatRoomRef.typeField, isEqualTo: type.name)
-          .get(),
+      InterviewType.commonPracticalTopic =>
+        await FirestoreChatRoomRef.collection()
+            .where(FirestoreChatRoomRef.typeField, isEqualTo: type.name)
+            .get(),
       InterviewType.resume => await FirestoreChatRoomRef.collection()
           .where(FirestoreChatRoomRef.typeField, isEqualTo: type.name)
           .get(),

--- a/lib/features/chat/data_source/remote/chat_remote_data_source_impl.dart
+++ b/lib/features/chat/data_source/remote/chat_remote_data_source_impl.dart
@@ -176,6 +176,8 @@ final class ChatRemoteDataSourceImpl implements ChatRemoteDataSource {
           qnaDoc,
           ChatQnaModel(
             id: qnaDoc.id,
+            question: chatQna.question,
+            evaluationPoint: chatQna.evaluationPoint,
           ),
         );
       }

--- a/lib/features/chat/data_source/remote/chat_remote_data_source_impl.dart
+++ b/lib/features/chat/data_source/remote/chat_remote_data_source_impl.dart
@@ -3,6 +3,8 @@ import 'package:techtalk/app/di/modules/system_di.dart';
 import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/data_source/remote/models/follow_up_qna_model.dart';
+import 'package:techtalk/features/chat/data_source/remote/models/resume_field_model.dart';
+import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
 final class ChatRemoteDataSourceImpl implements ChatRemoteDataSource {
@@ -172,12 +174,18 @@ final class ChatRemoteDataSourceImpl implements ChatRemoteDataSource {
     await FirebaseFirestore.instance.runTransaction((transaction) async {
       for (final chatQna in chatQnas) {
         final qnaDoc = FirestoreChatQnaRef.doc(roomModel.id, chatQna.qna.id);
+        final qna = chatQna.qna;
         transaction.set(
           qnaDoc,
           ChatQnaModel(
             id: qnaDoc.id,
-            question: chatQna.question,
-            evaluationPoint: chatQna.evaluationPoint,
+            resumeField: qna.type.isResume
+                ? ResumeFieldModel(
+                    question: qna.question,
+                    evaluationPoint: (qna as ResumeQnaEntity).evaluationPoint,
+                    questionType: qna.questionType,
+                  )
+                : null,
           ),
         );
       }

--- a/lib/features/chat/data_source/remote/models/chat_qna_model.dart
+++ b/lib/features/chat/data_source/remote/models/chat_qna_model.dart
@@ -12,6 +12,8 @@ class ChatQnaModel {
     this.messageId,
     this.state,
     this.followUpQnas,
+    this.question,
+    this.evaluationPoint,
   });
 
   final String id;
@@ -19,15 +21,21 @@ class ChatQnaModel {
   final String? state;
   final List<FollowUpQnaModel>? followUpQnas;
 
+  /// 1.1.0 (이력서 면접)
+  final String? question;
+  final String? evaluationPoint;
+
   String get topicId => id.split('-').first;
 
-  factory ChatQnaModel.fromEntity(ChatQnaEntity entity) {
-    return ChatQnaModel(
-      id: entity.qna.id,
-      messageId: entity.message?.id,
-      state: entity.message?.answerState.tag,
-    );
-  }
+  // factory ChatQnaModel.fromEntity(ChatQnaEntity entity) {
+  //   return ChatQnaModel(
+  //     id: entity.qna.id,
+  //     messageId: entity.message?.id,
+  //     state: entity.message?.answerState.tag,
+  //     question: entity.question,
+  //     evaluationPoint: entity.evaluationPoint,
+  //   );
+  // }
 
   factory ChatQnaModel.fromFirestore(
     DocumentSnapshot<Map<String, dynamic>> snapshot,

--- a/lib/features/chat/data_source/remote/models/chat_qna_model.dart
+++ b/lib/features/chat/data_source/remote/models/chat_qna_model.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/data_source/remote/models/follow_up_qna_model.dart';
+import 'package:techtalk/features/chat/data_source/remote/models/resume_field_model.dart';
 
 part 'chat_qna_model.g.dart';
 
@@ -12,8 +12,7 @@ class ChatQnaModel {
     this.messageId,
     this.state,
     this.followUpQnas,
-    this.question,
-    this.evaluationPoint,
+    this.resumeField,
   });
 
   final String id;
@@ -22,20 +21,9 @@ class ChatQnaModel {
   final List<FollowUpQnaModel>? followUpQnas;
 
   /// 1.1.0 (이력서 면접)
-  final String? question;
-  final String? evaluationPoint;
+  ResumeFieldModel? resumeField;
 
   String get topicId => id.split('-').first;
-
-  // factory ChatQnaModel.fromEntity(ChatQnaEntity entity) {
-  //   return ChatQnaModel(
-  //     id: entity.qna.id,
-  //     messageId: entity.message?.id,
-  //     state: entity.message?.answerState.tag,
-  //     question: entity.question,
-  //     evaluationPoint: entity.evaluationPoint,
-  //   );
-  // }
 
   factory ChatQnaModel.fromFirestore(
     DocumentSnapshot<Map<String, dynamic>> snapshot,

--- a/lib/features/chat/data_source/remote/models/chat_qna_model.g.dart
+++ b/lib/features/chat/data_source/remote/models/chat_qna_model.g.dart
@@ -13,8 +13,10 @@ ChatQnaModel _$ChatQnaModelFromJson(Map<String, dynamic> json) => ChatQnaModel(
       followUpQnas: (json['follow_up_qnas'] as List<dynamic>?)
           ?.map((e) => FollowUpQnaModel.fromJson(e as Map<String, dynamic>))
           .toList(),
-      question: json['question'] as String?,
-      evaluationPoint: json['evaluation_point'] as String?,
+      resumeField: json['resume_field'] == null
+          ? null
+          : ResumeFieldModel.fromJson(
+              json['resume_field'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$ChatQnaModelToJson(ChatQnaModel instance) =>
@@ -23,6 +25,5 @@ Map<String, dynamic> _$ChatQnaModelToJson(ChatQnaModel instance) =>
       'message_id': instance.messageId,
       'state': instance.state,
       'follow_up_qnas': instance.followUpQnas?.map((e) => e.toJson()).toList(),
-      'question': instance.question,
-      'evaluation_point': instance.evaluationPoint,
+      'resume_field': instance.resumeField?.toJson(),
     };

--- a/lib/features/chat/data_source/remote/models/chat_qna_model.g.dart
+++ b/lib/features/chat/data_source/remote/models/chat_qna_model.g.dart
@@ -13,6 +13,8 @@ ChatQnaModel _$ChatQnaModelFromJson(Map<String, dynamic> json) => ChatQnaModel(
       followUpQnas: (json['follow_up_qnas'] as List<dynamic>?)
           ?.map((e) => FollowUpQnaModel.fromJson(e as Map<String, dynamic>))
           .toList(),
+      question: json['question'] as String?,
+      evaluationPoint: json['evaluation_point'] as String?,
     );
 
 Map<String, dynamic> _$ChatQnaModelToJson(ChatQnaModel instance) =>
@@ -21,4 +23,6 @@ Map<String, dynamic> _$ChatQnaModelToJson(ChatQnaModel instance) =>
       'message_id': instance.messageId,
       'state': instance.state,
       'follow_up_qnas': instance.followUpQnas?.map((e) => e.toJson()).toList(),
+      'question': instance.question,
+      'evaluation_point': instance.evaluationPoint,
     };

--- a/lib/features/chat/data_source/remote/models/chat_room_model.g.dart
+++ b/lib/features/chat/data_source/remote/models/chat_room_model.g.dart
@@ -30,7 +30,7 @@ Map<String, dynamic> _$ChatRoomModelToJson(ChatRoomModel instance) =>
     };
 
 const _$InterviewTypeEnumMap = {
-  InterviewType.singleTopic: 'singleTopic',
-  InterviewType.practical: 'practical',
+  InterviewType.commonSingleTopic: 'singleTopic',
+  InterviewType.commonPracticalTopic: 'practical',
   InterviewType.resume: 'resume',
 };

--- a/lib/features/chat/data_source/remote/models/chat_room_model.g.dart
+++ b/lib/features/chat/data_source/remote/models/chat_room_model.g.dart
@@ -30,7 +30,7 @@ Map<String, dynamic> _$ChatRoomModelToJson(ChatRoomModel instance) =>
     };
 
 const _$InterviewTypeEnumMap = {
-  InterviewType.commonSingleTopic: 'singleTopic',
-  InterviewType.commonPracticalTopic: 'practical',
+  InterviewType.commonSingleTopic: 'commonSingleTopic',
+  InterviewType.commonPracticalTopic: 'commonPracticalTopic',
   InterviewType.resume: 'resume',
 };

--- a/lib/features/chat/data_source/remote/models/resume_field_model.dart
+++ b/lib/features/chat/data_source/remote/models/resume_field_model.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:techtalk/features/chat/repositories/enums/resume_question_type.enum.dart';
+
+part 'resume_field_model.g.dart';
+
+///
+/// 1.1.0 (이력서 면접)
+/// 이력서 qna일 경우 매핑되어야하는 데이터 셋
+///
+@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+class ResumeFieldModel {
+  final String question;
+  final String evaluationPoint;
+  final ResumeQuestionType questionType;
+
+  ResumeFieldModel({
+    required this.question,
+    required this.evaluationPoint,
+    required this.questionType,
+  });
+
+  factory ResumeFieldModel.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+    SnapshotOptions? options,
+  ) =>
+      ResumeFieldModel.fromJson(snapshot.data()!);
+
+  factory ResumeFieldModel.fromJson(Map<String, dynamic> json) {
+    return _$ResumeFieldModelFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() => _$ResumeFieldModelToJson(this);
+}

--- a/lib/features/chat/data_source/remote/models/resume_field_model.g.dart
+++ b/lib/features/chat/data_source/remote/models/resume_field_model.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'resume_field_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ResumeFieldModel _$ResumeFieldModelFromJson(Map<String, dynamic> json) =>
+    ResumeFieldModel(
+      question: json['question'] as String,
+      evaluationPoint: json['evaluation_point'] as String,
+      questionType:
+          $enumDecode(_$ResumeQuestionTypeEnumMap, json['question_type']),
+    );
+
+Map<String, dynamic> _$ResumeFieldModelToJson(ResumeFieldModel instance) =>
+    <String, dynamic>{
+      'question': instance.question,
+      'evaluation_point': instance.evaluationPoint,
+      'question_type': _$ResumeQuestionTypeEnumMap[instance.questionType]!,
+    };
+
+const _$ResumeQuestionTypeEnumMap = {
+  ResumeQuestionType.hardSkill: 'hardSkill',
+  ResumeQuestionType.softSkill: 'softSkill',
+};

--- a/lib/features/chat/repositories/chat_repository.dart
+++ b/lib/features/chat/repositories/chat_repository.dart
@@ -34,9 +34,14 @@ abstract interface class ChatRepository {
   Future<Result<ChatHistoryCollectionEntity>> getChatHistory(String roomId);
 
   ///
-  /// 채팅 문답 리스트 호출
+  /// 채팅 단골 문답 리스트 호출
   ///
-  Future<Result<List<ChatQnaEntity>>> getChatQnas(ChatRoomEntity room);
+  Future<Result<List<ChatQnaEntity>>> getCommonChatQnas(ChatRoomEntity room);
+
+  ///
+  /// 이력서 문답 리스트 호출
+  ///
+  Future<Result<List<ChatQnaEntity>>> getResumeChatQnas(ChatRoomEntity room);
 
   ///
   /// 리포트 업로드

--- a/lib/features/chat/repositories/chat_repository_impl.dart
+++ b/lib/features/chat/repositories/chat_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/entities/follow_up_qna_entity.dart';
@@ -22,7 +24,8 @@ final class ChatRepositoryImpl implements ChatRepository {
       InterviewType.commonSingleTopic =>
         getChatRooms(room.type, room.topics.single),
       InterviewType.commonPracticalTopic => getChatRooms(room.type),
-      InterviewType.resume => throw Exception('타입을 지정해줘야 합니다'),
+      InterviewType.resume => getChatRooms(room.type),
+      // InterviewType.resume => throw Exception('타입을 지정해줘야 합니다'),
     }
         .then((value) => value.getOrThrow());
 
@@ -65,6 +68,7 @@ final class ChatRepositoryImpl implements ChatRepository {
 
       return Result.success(rooms);
     } on Exception catch (e) {
+      log('채팅방 목록 호출 실패 : ${e}');
       return Result.failure(const ChatRoomsFetchedFailedException());
     }
   }

--- a/lib/features/chat/repositories/chat_repository_impl.dart
+++ b/lib/features/chat/repositories/chat_repository_impl.dart
@@ -19,8 +19,9 @@ final class ChatRepositoryImpl implements ChatRepository {
     await _remoteDataSource.uploadChats(room.id, messages: messages);
 
     final rooms = await switch (room.type) {
-      InterviewType.singleTopic => getChatRooms(room.type, room.topics.single),
-      InterviewType.practical => getChatRooms(room.type),
+      InterviewType.commonSingleTopic =>
+        getChatRooms(room.type, room.topics.single),
+      InterviewType.commonPracticalTopic => getChatRooms(room.type),
       InterviewType.resume => throw Exception('타입을 지정해줘야 합니다'),
     }
         .then((value) => value.getOrThrow());

--- a/lib/features/chat/repositories/chat_repository_impl.dart
+++ b/lib/features/chat/repositories/chat_repository_impl.dart
@@ -121,7 +121,51 @@ final class ChatRepositoryImpl implements ChatRepository {
   }
 
   @override
-  Future<Result<List<ChatQnaEntity>>> getChatQnas(ChatRoomEntity room) async {
+  Future<Result<List<ChatQnaEntity>>> getResumeChatQnas(
+      ChatRoomEntity room) async {
+    try {
+      final fetchedQnas = await _remoteDataSource.getChatQnas(room.id);
+
+      final List<ChatQnaEntity> result = [];
+
+      await Future.forEach(
+        fetchedQnas,
+        (element) async {
+          // 응답 id가 있으면 응답 데이터 조회
+          final AnswerChatEntity? answer;
+
+          if (element.messageId != null) {
+            final message = await _remoteDataSource.getChat(
+              room.id,
+              element.messageId!,
+            );
+
+            answer = message.toEntity() as AnswerChatEntity;
+          } else {
+            answer = null;
+          }
+
+          result.add(
+            ChatQnaEntity.fromModelToResumeEntity(
+              model: element,
+              answerChatEntity: answer,
+              followUpQnaEntity: element.followUpQnas?.first != null
+                  ? FollowUpQnaEntity.fromModel(element.followUpQnas!.first)
+                  : null,
+            ),
+          );
+        },
+      );
+
+      return Result.success(result);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  @override
+  Future<Result<List<ChatQnaEntity>>> getCommonChatQnas(
+      ChatRoomEntity room) async {
     final roomQnAs = await _remoteDataSource.getChatQnas(room.id);
 
     final qnas = <ChatQnaEntity>[];

--- a/lib/features/chat/repositories/entities/base_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/base_qna_entity.dart
@@ -1,4 +1,5 @@
 import 'package:techtalk/features/chat/repositories/enums/qna_type.enum.dart';
+import 'package:uuid/uuid.dart';
 
 abstract class BaseQnaEntity {
   /// 고유 id 값
@@ -10,9 +11,9 @@ abstract class BaseQnaEntity {
   /// 문답 유형
   final QnaType type;
 
-  const BaseQnaEntity({
-    required this.id,
+  BaseQnaEntity({
+    String? id,
     required this.question,
     required this.type,
-  });
+  }) : id = id ?? const Uuid().v1();
 }

--- a/lib/features/chat/repositories/entities/chat_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_qna_entity.dart
@@ -2,6 +2,7 @@ import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/data_source/remote/models/follow_up_qna_model.dart';
 import 'package:techtalk/features/chat/repositories/entities/base_qna_entity.dart';
 import 'package:techtalk/features/chat/repositories/entities/follow_up_qna_entity.dart';
+import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
 class ChatQnaEntity {
@@ -9,26 +10,42 @@ class ChatQnaEntity {
   final AnswerChatEntity? message; // 유저 응답
   final FollowUpQnaEntity? followUpQna; // 꼬리 질문 응답
 
+  final String? question;
+  final String? evaluationPoint;
+
   bool get hasUserResponded => message != null;
 
   ChatQnaEntity({
     required this.qna,
     this.message,
     this.followUpQna,
+    this.question,
+    this.evaluationPoint,
   });
 
-  factory ChatQnaEntity.fromQnaEntity(CommonQnaEntity entity) =>
+  factory ChatQnaEntity.fromCommonQnaEntity(CommonQnaEntity entity) =>
       ChatQnaEntity(qna: entity);
 
+  factory ChatQnaEntity.fromResumeQnaEntity(ResumeQnaEntity entity) =>
+      ChatQnaEntity(
+        qna: entity,
+        question: entity.question,
+        evaluationPoint: entity.evaluationPoint,
+      );
+
   ChatQnaEntity copyWith({
-    CommonQnaEntity? qna,
+    BaseQnaEntity? qna,
     AnswerChatEntity? message,
     FollowUpQnaEntity? followUpQna,
+    String? question,
+    String? evaluationPoint,
   }) {
     return ChatQnaEntity(
       qna: qna ?? this.qna,
       message: message ?? this.message,
       followUpQna: followUpQna ?? this.followUpQna,
+      question: question ?? this.question,
+      evaluationPoint: evaluationPoint ?? this.evaluationPoint,
     );
   }
 }

--- a/lib/features/chat/repositories/entities/chat_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_qna_entity.dart
@@ -37,6 +37,7 @@ class ChatQnaEntity {
       evaluationPoint: resumeField.evaluationPoint,
       id: model.id,
     );
+
     return ChatQnaEntity(
       qna: targetQna,
       message: answerChatEntity,

--- a/lib/features/chat/repositories/entities/chat_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_qna_entity.dart
@@ -1,3 +1,4 @@
+import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/data_source/remote/models/follow_up_qna_model.dart';
 import 'package:techtalk/features/chat/repositories/entities/base_qna_entity.dart';
@@ -10,28 +11,38 @@ class ChatQnaEntity {
   final AnswerChatEntity? message; // 유저 응답
   final FollowUpQnaEntity? followUpQna; // 꼬리 질문 응답
 
-  final String? question;
-  final String? evaluationPoint;
-
   bool get hasUserResponded => message != null;
 
   ChatQnaEntity({
     required this.qna,
     this.message,
     this.followUpQna,
-    this.question,
-    this.evaluationPoint,
   });
 
-  factory ChatQnaEntity.fromCommonQnaEntity(CommonQnaEntity entity) =>
+  factory ChatQnaEntity.fromQnaEntityAtInitial(CommonQnaEntity entity) =>
       ChatQnaEntity(qna: entity);
 
-  factory ChatQnaEntity.fromResumeQnaEntity(ResumeQnaEntity entity) =>
-      ChatQnaEntity(
-        qna: entity,
-        question: entity.question,
-        evaluationPoint: entity.evaluationPoint,
-      );
+  factory ChatQnaEntity.fromResumeQnaEntityAtInitial(ResumeQnaEntity entity) =>
+      ChatQnaEntity(qna: entity);
+
+  factory ChatQnaEntity.fromModelToResumeEntity(
+      {required ChatQnaModel model,
+      required AnswerChatEntity? answerChatEntity,
+      required FollowUpQnaEntity? followUpQnaEntity}) {
+    final resumeField = model.resumeField!;
+
+    final targetQna = ResumeQnaEntity(
+      question: resumeField.question,
+      questionType: resumeField.questionType,
+      evaluationPoint: resumeField.evaluationPoint,
+      id: model.id,
+    );
+    return ChatQnaEntity(
+      qna: targetQna,
+      message: answerChatEntity,
+      followUpQna: followUpQnaEntity,
+    );
+  }
 
   ChatQnaEntity copyWith({
     BaseQnaEntity? qna,
@@ -44,8 +55,6 @@ class ChatQnaEntity {
       qna: qna ?? this.qna,
       message: message ?? this.message,
       followUpQna: followUpQna ?? this.followUpQna,
-      question: question ?? this.question,
-      evaluationPoint: evaluationPoint ?? this.evaluationPoint,
     );
   }
 }

--- a/lib/features/chat/repositories/entities/chat_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_qna_entity.dart
@@ -1,10 +1,11 @@
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/data_source/remote/models/follow_up_qna_model.dart';
+import 'package:techtalk/features/chat/repositories/entities/base_qna_entity.dart';
 import 'package:techtalk/features/chat/repositories/entities/follow_up_qna_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
 class ChatQnaEntity {
-  final CommonQnaEntity qna; // 문답
+  final BaseQnaEntity qna; // 문답
   final AnswerChatEntity? message; // 유저 응답
   final FollowUpQnaEntity? followUpQna; // 꼬리 질문 응답
 

--- a/lib/features/chat/repositories/entities/chat_room_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_room_entity.dart
@@ -80,10 +80,10 @@ class ChatRoomEntity {
 
   factory ChatRoomEntity.fromModel(ChatRoomModel roomModel) {
     final topics = switch (roomModel.type) {
-      InterviewType.singleTopic => [
+      InterviewType.commonSingleTopic => [
           StoredTopics.getById(roomModel.topicIds.first)
         ],
-      InterviewType.practical =>
+      InterviewType.commonPracticalTopic =>
         roomModel.topicIds.map(StoredTopics.getById).toList(),
       InterviewType.resume => throw Exception('타입을 지정해주어야 합니다'),
     };

--- a/lib/features/chat/repositories/entities/chat_room_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_room_entity.dart
@@ -109,7 +109,7 @@ class ChatRoomEntity {
         ],
       InterviewType.commonPracticalTopic =>
         roomModel.topicIds.map(StoredTopics.getById).toList(),
-      InterviewType.resume => throw Exception('타입을 지정해주어야 합니다'),
+      InterviewType.resume => <TopicEntity>[],
     };
 
     return ChatRoomEntity(

--- a/lib/features/chat/repositories/entities/chat_room_entity.dart
+++ b/lib/features/chat/repositories/entities/chat_room_entity.dart
@@ -1,6 +1,8 @@
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/core/helper/string_generator.dart';
 import 'package:techtalk/features/chat/chat.dart';
+import 'package:techtalk/features/chat/repositories/entities/base_qna_entity.dart';
+import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
 class ChatRoomEntity {
@@ -14,6 +16,9 @@ class ChatRoomEntity {
   final bool isTemporary;
   final List<String>? qnaIds;
 
+  /// [InterviewType.resume]
+  final List<BaseQnaEntity> qnas;
+
   const ChatRoomEntity({
     required this.type,
     required this.id,
@@ -24,6 +29,7 @@ class ChatRoomEntity {
     this.lastChatMessage,
     this.lastChatDate,
     this.isTemporary = false,
+    this.qnas = const [],
   });
 
   ChatRoomProgress get progressState {
@@ -61,7 +67,8 @@ class ChatRoomEntity {
 
   TopicEntity get singleTopic => topics.first;
 
-  factory ChatRoomEntity.random({
+  /// 단골 면접 질문
+  factory ChatRoomEntity.generateCommonInterview({
     required InterviewType type,
     required List<TopicEntity> topics,
     required int questionCount,
@@ -78,6 +85,23 @@ class ChatRoomEntity {
     );
   }
 
+  /// 이력서 면접 질문
+  factory ChatRoomEntity.generateResumeInterview({
+    required List<ResumeQnaEntity> qnas,
+  }) {
+    return ChatRoomEntity(
+      isTemporary: true,
+      type: InterviewType.resume,
+      id: StringGenerator.generateRandomString(),
+      interviewer: Interviewer.getRandomInterviewer(),
+      qnas: qnas,
+      topics: [],
+      progressInfo: ChatProgressInfoEntity.onInitial(
+        totalQuestionCount: qnas.length,
+      ),
+    );
+  }
+
   factory ChatRoomEntity.fromModel(ChatRoomModel roomModel) {
     final topics = switch (roomModel.type) {
       InterviewType.commonSingleTopic => [
@@ -87,11 +111,6 @@ class ChatRoomEntity {
         roomModel.topicIds.map(StoredTopics.getById).toList(),
       InterviewType.resume => throw Exception('타입을 지정해주어야 합니다'),
     };
-
-    final progress = roomModel.totalQuestionCount ==
-            roomModel.correctAnswerCount + roomModel.incorrectAnswerCount
-        ? ChatRoomProgress.completed
-        : ChatRoomProgress.ongoing;
 
     return ChatRoomEntity(
       type: roomModel.type,
@@ -109,7 +128,7 @@ class ChatRoomEntity {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      (other is ChatRoomEntity &&
+      other is ChatRoomEntity &&
           runtimeType == other.runtimeType &&
           type == other.type &&
           id == other.id &&
@@ -118,7 +137,9 @@ class ChatRoomEntity {
           progressInfo == other.progressInfo &&
           lastChatMessage == other.lastChatMessage &&
           lastChatDate == other.lastChatDate &&
-          isTemporary == other.isTemporary);
+          isTemporary == other.isTemporary &&
+          qnaIds == other.qnaIds &&
+          qnas == other.qnas;
 
   @override
   int get hashCode =>
@@ -129,45 +150,33 @@ class ChatRoomEntity {
       progressInfo.hashCode ^
       lastChatMessage.hashCode ^
       lastChatDate.hashCode ^
-      isTemporary.hashCode;
-
-  @override
-  String toString() {
-    return 'ChatRoomEntity{' +
-        ' type: $type,' +
-        ' id: $id,' +
-        ' interviewer: $interviewer,' +
-        ' topics: $topics,' +
-        ' progressInfo: $progressInfo,' +
-        ' lastChatMessage: $lastChatMessage,' +
-        ' lastChatDate: $lastChatDate,' +
-        ' isTemporary: $isTemporary,' +
-        '}';
-  }
+      isTemporary.hashCode ^
+      qnaIds.hashCode ^
+      qnas.hashCode;
 
   ChatRoomEntity copyWith({
+    InterviewType? type,
     String? id,
     Interviewer? interviewer,
     List<TopicEntity>? topics,
     ChatProgressInfoEntity? progressInfo,
     String? lastChatMessage,
     DateTime? lastChatDate,
-    ChatRoomProgress? chatProgressState,
     bool? isTemporary,
     List<String>? qnaIds,
+    List<BaseQnaEntity>? qnas,
   }) {
     return ChatRoomEntity(
+      type: type ?? this.type,
       id: id ?? this.id,
-      type: type,
       interviewer: interviewer ?? this.interviewer,
       topics: topics ?? this.topics,
-      qnaIds: qnaIds ?? this.qnaIds,
       progressInfo: progressInfo ?? this.progressInfo,
       lastChatMessage: lastChatMessage ?? this.lastChatMessage,
       lastChatDate: lastChatDate ?? this.lastChatDate,
       isTemporary: isTemporary ?? this.isTemporary,
+      qnaIds: qnaIds ?? this.qnaIds,
+      qnas: qnas ?? this.qnas,
     );
   }
-
-//</editor-fold>
 }

--- a/lib/features/chat/repositories/entities/resume_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/resume_qna_entity.dart
@@ -2,7 +2,7 @@ import 'package:techtalk/features/chat/repositories/entities/base_qna_entity.dar
 import 'package:techtalk/features/chat/repositories/enums/qna_type.enum.dart';
 import 'package:techtalk/features/chat/repositories/enums/resume_question_type.enum.dart';
 
-const List<ResumeQnaEntity> _temp = [
+final List<ResumeQnaEntity> tempResumeQnaList = [
   // 하드스킬 질문 1
   ResumeQnaEntity(
     id: '1',
@@ -90,7 +90,7 @@ class ResumeQnaEntity extends BaseQnaEntity {
   /// 하드스킬, 소프스킬 질문 타입
   final ResumeQuestionType questionType;
 
-  const ResumeQnaEntity({
+  ResumeQnaEntity({
     required super.id,
     required super.question,
     required this.questionType,

--- a/lib/features/chat/repositories/entities/resume_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/resume_qna_entity.dart
@@ -5,14 +5,14 @@ import 'package:techtalk/features/chat/repositories/enums/resume_question_type.e
 final List<ResumeQnaEntity> tempResumeQnaList = [
   // 하드스킬 질문 1
   ResumeQnaEntity(
-    id: '1',
+    id: 'resume-1',
     question: '중고나라 앱에서 딥링크 구조를 개선한 작업에서 가장 큰 도전 과제와 이를 해결하기 위한 접근법은 무엇인가요?',
     questionType: ResumeQuestionType.hardSkill,
     evaluationPoint: '문제 정의 및 해결 능력, 추상화 설계 경험, 코드 개선의 실질적 효과',
   ),
   // 하드스킬 질문 2
   ResumeQnaEntity(
-    id: '2',
+    id: 'resume-2',
     question:
         'Firebase A/B 테스트를 활용해 광고 매출을 12.4% 증가시켰다고 했는데, 실험 설계와 데이터 분석 과정은 어떻게 진행되었나요?',
     questionType: ResumeQuestionType.hardSkill,
@@ -20,7 +20,7 @@ final List<ResumeQnaEntity> tempResumeQnaList = [
   ),
   // 하드스킬 질문 3
   ResumeQnaEntity(
-    id: '3',
+    id: 'resume-3',
     question:
         'Pets Next Door 프로젝트에서 Riverpod와 Clean Architecture를 결합하여 얻은 주요 성과는 무엇인가요?',
     questionType: ResumeQuestionType.hardSkill,
@@ -28,7 +28,7 @@ final List<ResumeQnaEntity> tempResumeQnaList = [
   ),
   // 하드스킬 질문 4
   ResumeQnaEntity(
-    id: '4',
+    id: 'resume-4',
     question:
         'Flutter와 네이티브 코드를 통합하여 로그인 기능을 구현할 때 어떤 접근을 사용했으며, 이를 통해 얻은 결과는 무엇인가요?',
     questionType: ResumeQuestionType.hardSkill,
@@ -37,42 +37,42 @@ final List<ResumeQnaEntity> tempResumeQnaList = [
   ),
   // 하드스킬 질문 5
   ResumeQnaEntity(
-    id: '5',
+    id: 'resume-5',
     question: 'go_router를 활용한 Nested Navigation을 구현하며 겪은 기술적 도전과 해결 방법은 무엇인가요?',
     questionType: ResumeQuestionType.hardSkill,
     evaluationPoint: '복잡한 네비게이션 구현 능력, 코드 구조 개선 및 문제 해결 능력',
   ),
   // 소프트스킬 질문 1
   ResumeQnaEntity(
-    id: '6',
+    id: 'resume-6',
     question: '협업 과정에서 겪은 가장 어려운 상황과 이를 해결하기 위해 사용한 방법은 무엇인가요?',
     questionType: ResumeQuestionType.softSkill,
     evaluationPoint: '팀워크 및 커뮤니케이션 능력, 갈등 해결 및 문제 극복 역량',
   ),
   // 소프트스킬 질문 2
   ResumeQnaEntity(
-    id: '7',
+    id: 'resume-7',
     question: '"기획 변경에도 유연하게 대처할 수 있는 코드를 작성했다"고 했는데, 이를 위해 어떤 노력을 기울였나요?',
     questionType: ResumeQuestionType.softSkill,
     evaluationPoint: '변화에 적응할 수 있는 유연성, 코드 품질과 설계 역량',
   ),
   // 소프트스킬 질문 3
   ResumeQnaEntity(
-    id: '8',
+    id: 'resume-8',
     question: '블로그나 오픈소스 프로젝트를 통해 다른 개발자들에게 긍정적인 영향을 준 사례를 소개해주세요.',
     questionType: ResumeQuestionType.softSkill,
     evaluationPoint: '커뮤니티 기여 경험, 지식 공유에 대한 열정 및 지속적 학습 태도',
   ),
   // 소프트스킬 질문 4
   ResumeQnaEntity(
-    id: '9',
+    id: 'resume-9',
     question: 'Flutter와 관련된 최신 기술 트렌드를 어떻게 파악하고, 실무에 적용했는지 설명해주세요.',
     questionType: ResumeQuestionType.softSkill,
     evaluationPoint: '자기 주도 학습 능력, 최신 기술 도입 및 적용 능력',
   ),
   // 소프트스킬 질문 5
   ResumeQnaEntity(
-    id: '10',
+    id: 'resume-10',
     question: '기술적 고민이 협업과 비즈니스에 긍정적인 영향을 미쳤다고 했는데, 구체적으로 어떤 사례가 있나요?',
     questionType: ResumeQuestionType.softSkill,
     evaluationPoint: '기술적 기여를 통해 협업 및 비즈니스 성과에 기여한 경험, 팀과 비즈니스 간의 연계 이해력',
@@ -91,11 +91,12 @@ class ResumeQnaEntity extends BaseQnaEntity {
   final ResumeQuestionType questionType;
 
   ResumeQnaEntity({
-    required super.id,
+    String? id,
     required super.question,
     required this.questionType,
     required this.evaluationPoint,
   }) : super(
+          id: id,
           type: QnaType.resume,
         );
 

--- a/lib/features/chat/repositories/entities/resume_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/resume_qna_entity.dart
@@ -26,36 +26,36 @@ final List<ResumeQnaEntity> tempResumeQnaList = [
     questionType: ResumeQuestionType.hardSkill,
     evaluationPoint: '상태 관리와 아키텍처 설계에 대한 이해, 실무 적용 능력, 협업 및 코드 유지보수성',
   ),
-  // 하드스킬 질문 4
-  ResumeQnaEntity(
-    id: 'resume-4',
-    question:
-        'Flutter와 네이티브 코드를 통합하여 로그인 기능을 구현할 때 어떤 접근을 사용했으며, 이를 통해 얻은 결과는 무엇인가요?',
-    questionType: ResumeQuestionType.hardSkill,
-    evaluationPoint:
-        'Flutter와 네이티브 코드 통합 기술, Firebase Auth 활용 능력, 테스트 코드 작성 및 검증 경험',
-  ),
-  // 하드스킬 질문 5
-  ResumeQnaEntity(
-    id: 'resume-5',
-    question: 'go_router를 활용한 Nested Navigation을 구현하며 겪은 기술적 도전과 해결 방법은 무엇인가요?',
-    questionType: ResumeQuestionType.hardSkill,
-    evaluationPoint: '복잡한 네비게이션 구현 능력, 코드 구조 개선 및 문제 해결 능력',
-  ),
-  // 소프트스킬 질문 1
-  ResumeQnaEntity(
-    id: 'resume-6',
-    question: '협업 과정에서 겪은 가장 어려운 상황과 이를 해결하기 위해 사용한 방법은 무엇인가요?',
-    questionType: ResumeQuestionType.softSkill,
-    evaluationPoint: '팀워크 및 커뮤니케이션 능력, 갈등 해결 및 문제 극복 역량',
-  ),
-  // 소프트스킬 질문 2
-  ResumeQnaEntity(
-    id: 'resume-7',
-    question: '"기획 변경에도 유연하게 대처할 수 있는 코드를 작성했다"고 했는데, 이를 위해 어떤 노력을 기울였나요?',
-    questionType: ResumeQuestionType.softSkill,
-    evaluationPoint: '변화에 적응할 수 있는 유연성, 코드 품질과 설계 역량',
-  ),
+  // // 하드스킬 질문 4
+  // ResumeQnaEntity(
+  //   id: 'resume-4',
+  //   question:
+  //       'Flutter와 네이티브 코드를 통합하여 로그인 기능을 구현할 때 어떤 접근을 사용했으며, 이를 통해 얻은 결과는 무엇인가요?',
+  //   questionType: ResumeQuestionType.hardSkill,
+  //   evaluationPoint:
+  //       'Flutter와 네이티브 코드 통합 기술, Firebase Auth 활용 능력, 테스트 코드 작성 및 검증 경험',
+  // ),
+  // // 하드스킬 질문 5
+  // ResumeQnaEntity(
+  //   id: 'resume-5',
+  //   question: 'go_router를 활용한 Nested Navigation을 구현하며 겪은 기술적 도전과 해결 방법은 무엇인가요?',
+  //   questionType: ResumeQuestionType.hardSkill,
+  //   evaluationPoint: '복잡한 네비게이션 구현 능력, 코드 구조 개선 및 문제 해결 능력',
+  // ),
+  // // 소프트스킬 질문 1
+  // ResumeQnaEntity(
+  //   id: 'resume-6',
+  //   question: '협업 과정에서 겪은 가장 어려운 상황과 이를 해결하기 위해 사용한 방법은 무엇인가요?',
+  //   questionType: ResumeQuestionType.softSkill,
+  //   evaluationPoint: '팀워크 및 커뮤니케이션 능력, 갈등 해결 및 문제 극복 역량',
+  // ),
+  // // 소프트스킬 질문 2
+  // ResumeQnaEntity(
+  //   id: 'resume-7',
+  //   question: '"기획 변경에도 유연하게 대처할 수 있는 코드를 작성했다"고 했는데, 이를 위해 어떤 노력을 기울였나요?',
+  //   questionType: ResumeQuestionType.softSkill,
+  //   evaluationPoint: '변화에 적응할 수 있는 유연성, 코드 품질과 설계 역량',
+  // ),
   // 소프트스킬 질문 3
   ResumeQnaEntity(
     id: 'resume-8',

--- a/lib/features/chat/repositories/enums/interview_type.enum.dart
+++ b/lib/features/chat/repositories/enums/interview_type.enum.dart
@@ -1,17 +1,38 @@
 import 'package:techtalk/core/constants/assets.dart';
 
 enum InterviewType {
-  singleTopic(Assets.imagesInductionPractical),
-  practical(Assets.imagesInductionSingle),
+  commonSingleTopic(Assets.imagesInductionPractical),
+  commonPracticalTopic(Assets.imagesInductionSingle),
   resume(Assets.imagesInductionResume);
 
-  bool get isSingleTopic => this == InterviewType.singleTopic;
-  bool get isPractical => this == InterviewType.practical;
+  bool get isSingleTopic => this == InterviewType.commonSingleTopic;
+
+  bool get isPractical => this == InterviewType.commonPracticalTopic;
+
+  bool get isCommonQuestionType =>
+      this == InterviewType.commonSingleTopic ||
+      this == InterviewType.commonPracticalTopic;
+
   bool get isResume => this == InterviewType.resume;
 
   const InterviewType(this.illusrationPath);
 
   final String illusrationPath;
+
+  R typedBranch<R>({
+    required R Function(InterviewType type) common,
+    required R Function(InterviewType type) resume,
+  }) {
+    switch (this) {
+      case InterviewType.commonSingleTopic ||
+            InterviewType.commonPracticalTopic:
+        return common(this);
+      case InterviewType.resume:
+        return resume(this);
+      default:
+        throw Exception('잘못된 타입입니다 : $this');
+    }
+  }
 
   R branch<R>({
     required R Function(InterviewType type) singleTopic,
@@ -19,9 +40,9 @@ enum InterviewType {
     required R Function(InterviewType type) resume,
   }) {
     switch (this) {
-      case InterviewType.singleTopic:
+      case InterviewType.commonSingleTopic:
         return singleTopic(this);
-      case InterviewType.practical:
+      case InterviewType.commonPracticalTopic:
         return practical(this);
       case InterviewType.resume:
         return resume(this);

--- a/lib/features/chat/repositories/enums/interview_type.enum.dart
+++ b/lib/features/chat/repositories/enums/interview_type.enum.dart
@@ -13,21 +13,20 @@ enum InterviewType {
 
   final String illusrationPath;
 
-  static R branch<R>({
-    required InterviewType targetType,
+  R branch<R>({
     required R Function(InterviewType type) singleTopic,
     required R Function(InterviewType type) practical,
     required R Function(InterviewType type) resume,
   }) {
-    switch (targetType) {
+    switch (this) {
       case InterviewType.singleTopic:
-        return singleTopic(targetType);
+        return singleTopic(this);
       case InterviewType.practical:
-        return practical(targetType);
+        return practical(this);
       case InterviewType.resume:
-        return resume(targetType);
+        return resume(this);
       default:
-        throw Exception('잘못된 타입입니다 : $targetType');
+        throw Exception('잘못된 타입입니다 : $this');
     }
   }
 }

--- a/lib/features/chat/repositories/enums/qna_type.enum.dart
+++ b/lib/features/chat/repositories/enums/qna_type.enum.dart
@@ -5,4 +5,8 @@ enum QnaType {
   common, // 단골 면접 질문,
   resume, // 이력서(+포트폴리오) 면접 질문
   youtube; // 유튜브 콘텐츠 기발 면접 질문
+
+  bool get isCommon => this == QnaType.common;
+  bool get isResume => this == QnaType.resume;
+  bool get isYoutube => this == QnaType.youtube;
 }

--- a/lib/features/chat/use_cases/get_chat_qnas_use_case.dart
+++ b/lib/features/chat/use_cases/get_chat_qnas_use_case.dart
@@ -5,7 +5,11 @@ final class GetChatQnasUseCase {
   GetChatQnasUseCase(this._chatRepository);
 
   final ChatRepository _chatRepository;
+
   Future<Result<List<ChatQnaEntity>>> call(ChatRoomEntity room) async {
-    return _chatRepository.getChatQnas(room);
+    return room.type.typedBranch(
+      common: (_) => _chatRepository.getCommonChatQnas(room),
+      resume: (_) => _chatRepository.getResumeChatQnas(room),
+    );
   }
 }

--- a/lib/features/chat/use_cases/get_one_line_interview_feedback_use_case.dart
+++ b/lib/features/chat/use_cases/get_one_line_interview_feedback_use_case.dart
@@ -72,8 +72,27 @@ class GetOneLineInterViewFeedbackUseCase extends BaseNoFutureUseCase<
     return [
       Messages(
         role: Role.system,
+        content: '당신은 면접관으로서 지원자에게 종합적인 한 줄 평 피드백을 제공해야 합니다.',
+      ).toJson(),
+      param.interviewType.typedBranch(
+        common: (_) {
+          return Messages(
+            role: Role.system,
+            content:
+                '개발자 면접 주제는 ${param.topic.map((e) => StoredTopics.getById(e.id).text).join(' ')}입니다.',
+          ).toJson();
+        },
+        resume: (_) {
+          return Messages(
+            role: Role.system,
+            content: '지원자의 개발자 이력서와 포트폴리오를 기반으로 면접과 답변을 주고 받았습니다.',
+          ).toJson();
+        },
+      ),
+      Messages(
+        role: Role.system,
         content:
-            '당신은 면접관으로서 지원자에게 종합적인 한 줄 평 피드백을 제공해야 합니다. 개발자 면접 주제는 ${param.topic.map((e) => '${StoredTopics.getById(e.id).text}').join(' ')}입니다. 피드백은 ${AppLocale.currentLocale.languageCode}로 작성하며, 면접관과 지원자 주고 받은 대화 기록은 아래와 같습니다.',
+            '피드백은 ${AppLocale.currentLocale.languageCode}로 작성하며, 면접관과 지원자 주고 받은 대화 기록은 아래와 같습니다.',
       ).toJson(),
       ...param.chatHistory.map(
         (element) => switch (element) {
@@ -108,6 +127,7 @@ class GetOneLineInterViewFeedbackParam {
   final List<TopicEntity> topic;
   final List<BaseChatEntity> chatHistory;
   final InterviewResult interviewResult;
+  final InterviewType interviewType;
   final void Function(Object error, StackTrace startTrace) onError;
 
   const GetOneLineInterViewFeedbackParam({
@@ -115,5 +135,6 @@ class GetOneLineInterViewFeedbackParam {
     required this.interviewResult,
     required this.topic,
     required this.onError,
+    required this.interviewType,
   });
 }

--- a/lib/features/chat/use_cases/get_random_qnas_use_case.dart
+++ b/lib/features/chat/use_cases/get_random_qnas_use_case.dart
@@ -22,7 +22,7 @@ class GetRandomQnasUseCase
     try {
       final returnedQnas = switch (room.type) {
         /// 주제별 면접
-        InterviewType.singleTopic => () async {
+        InterviewType.commonSingleTopic => () async {
             final qnas = await _topicRepository
                 .getTopicQnas(room.singleTopic.id)
                 .then((value) => value.getOrThrow());
@@ -34,7 +34,7 @@ class GetRandomQnasUseCase
           },
 
         /// 실전 면접
-        InterviewType.practical => () async {
+        InterviewType.commonPracticalTopic => () async {
             final shuffledTopics = room.topics.toList()..shuffle();
             final List<CommonQnaEntity> resolvedQnas = [];
             final topicCount = shuffledTopics.length;

--- a/lib/features/chat/use_cases/get_random_qnas_use_case.dart
+++ b/lib/features/chat/use_cases/get_random_qnas_use_case.dart
@@ -30,7 +30,7 @@ class GetRandomQnasUseCase
             final filteredQnas = qnas.extractFromFirstAndShuffle(
                 room.progressInfo.totalQuestionCount);
 
-            return filteredQnas.map(ChatQnaEntity.fromQnaEntity).toList();
+            return filteredQnas.map(ChatQnaEntity.fromCommonQnaEntity).toList();
           },
 
         /// 실전 면접
@@ -60,7 +60,7 @@ class GetRandomQnasUseCase
             resolvedQnas.shuffle();
 
             final chatQns =
-                resolvedQnas.map(ChatQnaEntity.fromQnaEntity).toList();
+                resolvedQnas.map(ChatQnaEntity.fromCommonQnaEntity).toList();
 
             return chatQns;
           },

--- a/lib/features/chat/use_cases/get_random_qnas_use_case.dart
+++ b/lib/features/chat/use_cases/get_random_qnas_use_case.dart
@@ -30,7 +30,9 @@ class GetRandomQnasUseCase
             final filteredQnas = qnas.extractFromFirstAndShuffle(
                 room.progressInfo.totalQuestionCount);
 
-            return filteredQnas.map(ChatQnaEntity.fromCommonQnaEntity).toList();
+            return filteredQnas
+                .map(ChatQnaEntity.fromQnaEntityAtInitial)
+                .toList();
           },
 
         /// 실전 면접
@@ -60,7 +62,7 @@ class GetRandomQnasUseCase
             resolvedQnas.shuffle();
 
             final chatQns =
-                resolvedQnas.map(ChatQnaEntity.fromCommonQnaEntity).toList();
+                resolvedQnas.map(ChatQnaEntity.fromQnaEntityAtInitial).toList();
 
             return chatQns;
           },

--- a/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
@@ -9,6 +9,7 @@ import 'package:techtalk/app/localization/app_locale.dart';
 import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/entities/feedback_response_entity.dart';
+import 'package:techtalk/features/topic/repositories/entities/common_qna_entity.dart';
 
 class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
     BehaviorSubject<String>> {
@@ -107,6 +108,7 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
   List<Map<String, dynamic>> _createChatMessage(
       GetQuestionFeedbackParam param) {
     // 프롬프트는 추후 전부 한 언어로 통일할 것이므로 따로 localization은 필요하지 않아 보입니다.
+
     return [
       Messages(
         role: Role.system,
@@ -136,7 +138,7 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
       Messages(
         role: Role.system,
         content:
-            '면접 질문에 대한 모범답안은 다음과 같습니다: ${param.qna.qna.answers.map((str) => '-$str').join(' ')}',
+            '면접 질문에 대한 모범답안은 다음과 같습니다: ${(param.qna.qna as CommonQnaEntity).answers.map((str) => '-$str').join(' ')}',
       ).toJson(),
       Messages(
         role: Role.system,

--- a/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_feedback_use_case.dart
@@ -110,11 +110,20 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
     // 프롬프트는 추후 전부 한 언어로 통일할 것이므로 따로 localization은 필요하지 않아 보입니다.
 
     return [
-      Messages(
-        role: Role.system,
-        content:
-            '면접 질문을 물어보고 유저 답변의 정답 여부를 확인합니다. 당신은 면접관, 유저는 지원자입니다. 이제부터 진행할 면접은 ${StoredTopics.getById(param.qna.qna.id.getFirstPartOfSpliited).text}와 관련된 질문입니다. ${AppLocale.currentLocale.languageCode}언어로 면접을 진행합니다.',
-      ).toJson(),
+      param.interviewType.typedBranch(common: (_) {
+        return Messages(
+          role: Role.system,
+          content:
+              '면접 질문을 물어보고 유저 답변의 정답 여부를 확인합니다. 당신은 면접관, 유저는 지원자입니다. 이제부터 진행할 면접은 ${StoredTopics.getById(param.qna.qna.id.getFirstPartOfSpliited).text}와 관련된 질문입니다. ${AppLocale.currentLocale.languageCode}언어로 면접을 진행합니다.',
+        ).toJson();
+      }, resume: (_) {
+        return Messages(
+          role: Role.system,
+          content:
+              '면접 질문을 물어보고 유저 답변의 정답 여부를 확인합니다. 당신은 면접관, 유저는 지원자입니다. 유저의 개발자 이력서 또는 포트폴로리오에 관련된 질문입니다. ${AppLocale.currentLocale.languageCode}언어로 면접을 진행합니다.',
+        ).toJson();
+      }),
+
       ...param.chatHistory.map(
         (element) => switch (element) {
           QuestionChatEntity() => Messages(
@@ -135,11 +144,14 @@ class SetAiFeedbackUseCase extends BaseNoFutureUseCase<GetQuestionFeedbackParam,
             ).toJson()
         },
       ),
-      Messages(
-        role: Role.system,
-        content:
-            '면접 질문에 대한 모범답안은 다음과 같습니다: ${(param.qna.qna as CommonQnaEntity).answers.map((str) => '-$str').join(' ')}',
-      ).toJson(),
+
+      /// 단골질문 interview일 경우에만
+      if (param.interviewType.isCommonQuestionType)
+        Messages(
+          role: Role.system,
+          content:
+              '면접 질문에 대한 모범답안은 다음과 같습니다: ${(param.qna.qna as CommonQnaEntity).answers.map((str) => '-$str').join(' ')}',
+        ).toJson(),
       Messages(
         role: Role.system,
         content:
@@ -238,6 +250,7 @@ typedef GetQuestionFeedbackParam = ({
   List<BaseChatEntity> chatHistory,
   ChatQnaEntity qna,
   String userName,
+  InterviewType interviewType,
   void Function(
       {required FeedbackResponseEntity feedbackResponse}) onFeedBackCompleted,
   void Function({required AnswerState answerState}) checkAnswer,

--- a/lib/features/chat/use_cases/set_ai_follow_up_question_use_case.dart
+++ b/lib/features/chat/use_cases/set_ai_follow_up_question_use_case.dart
@@ -29,6 +29,7 @@ class SetAiFollowUpQuestionUseCase extends BaseNoFutureUseCase<
           messages: _createChatMessage(
             chatHistory: param.chatHistory,
             rootQna: param.rootQna,
+            type: param.interviewType,
           ),
           maxToken: 300,
           model: Gpt4ChatModel(),
@@ -36,7 +37,8 @@ class SetAiFollowUpQuestionUseCase extends BaseNoFutureUseCase<
           stream: true,
           user: FirebaseAuth.instance.currentUser!.uid,
         ),
-      )  .transform(
+      )
+          .transform(
         StreamTransformer.fromHandlers(
           handleError: (error, stackTrace, sink) {
             param.onError(error, stackTrace);
@@ -71,15 +73,36 @@ class SetAiFollowUpQuestionUseCase extends BaseNoFutureUseCase<
     }
   }
 
-  List<Map<String, dynamic>> _createChatMessage(
-      {required List<BaseChatEntity> chatHistory,
-      required ChatQnaEntity rootQna}) {
+  List<Map<String, dynamic>> _createChatMessage({
+    required List<BaseChatEntity> chatHistory,
+    required ChatQnaEntity rootQna,
+    required InterviewType type,
+  }) {
     // 프롬프트는 추후 전부 한 언어로 통일할 것이므로 따로 localization은 필요하지 않아 보입니다.
     return [
       Messages(
         role: Role.system,
+        content: '당신은 면접관, 유저는 지원자입니다. 유저의 마지막 답변을 기반으로 적절한 꼬리질문(연관질문)을 제공합니다.',
+      ).toJson(),
+      type.typedBranch(
+        common: (_) {
+          return Messages(
+            role: Role.system,
+            content:
+                '면접주제는 ${StoredTopics.getById(rootQna.qna.id.getFirstPartOfSpliited).text} 프로그래밍 입니다.',
+          ).toJson();
+        },
+        resume: (_) {
+          return Messages(
+            role: Role.system,
+            content: '유저의 개발자 이력서와 포트폴리오를 기반으로 면접 질문을 물어보았습니다',
+          ).toJson();
+        },
+      ),
+      Messages(
+        role: Role.system,
         content:
-            '당신은 면접관, 유저는 지원자입니다. 유저의 마지막 답변을 기반으로 적절한 꼬리질문(연관질문)을 제공합니다.면접주제는 ${StoredTopics.getById(rootQna.qna.id.getFirstPartOfSpliited).text} 프로그래밍 입니다. 꼬리 질문은 유저의 면접 질문 답변에 대해 심화적이고 날카로운 질문을 제공하세요. ${AppLocale.currentLocale.languageCode}언어로 꼬리질문을 생성하세요.',
+            '꼬리 질문은 유저의 면접 질문 답변에 대해 심화적이고 날카로운 질문을 제공하세요. ${AppLocale.currentLocale.languageCode}언어로 꼬리질문을 생성하세요',
       ).toJson(),
       ...chatHistory.map(
         (element) => switch (element) {
@@ -115,6 +138,7 @@ class SetAiFollowUpQuestionUseCase extends BaseNoFutureUseCase<
 
 /// [SetAiFollowUpQuestionUseCase] 파라미터
 typedef GetFollowUpQuestionParam = ({
+  InterviewType interviewType,
   List<BaseChatEntity> chatHistory,
   ChatQnaEntity rootQna,
   String userName,

--- a/lib/features/topic/data_source/remote/models/topic_model.g.dart
+++ b/lib/features/topic/data_source/remote/models/topic_model.g.dart
@@ -31,6 +31,6 @@ Map<String, dynamic> _$TopicModelToJson(TopicModel instance) =>
       'en_name': instance.enName,
       'image_path': instance.imagePath,
       'is_available': instance.isAvailable,
-      'related_topics': instance.relatedSkillIds,
+      'related_skill_ids': instance.relatedSkillIds,
       'updated_at': const TimeStampConverter().toJson(instance.updatedAt),
     };

--- a/lib/features/topic/repositories/entities/common_qna_entity.dart
+++ b/lib/features/topic/repositories/entities/common_qna_entity.dart
@@ -7,7 +7,7 @@ import 'package:techtalk/features/chat/repositories/enums/qna_type.enum.dart';
 class CommonQnaEntity extends BaseQnaEntity {
   final List<String> answers; // 모범 답변 리스트
 
-  const CommonQnaEntity({
+  CommonQnaEntity({
     required super.id,
     required super.question,
     required this.answers,

--- a/lib/presentation/pages/home/home_event.dart
+++ b/lib/presentation/pages/home/home_event.dart
@@ -9,6 +9,7 @@ import 'package:techtalk/app/router/router.dart';
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
+import 'package:techtalk/features/chat/repositories/enums/resume_question_type.enum.dart';
 import 'package:techtalk/presentation/pages/interview/chat_list/providers/practical_chat_room_list_provider.dart';
 import 'package:techtalk/presentation/providers/main_bottom_navigation_provider.dart';
 import 'package:techtalk/presentation/providers/system/notification_status_provider.dart';
@@ -24,18 +25,6 @@ mixin class HomeEvent {
   /// 실전 면접 기록 여부에 따라 라우팅을 다르게 진행
   ///
   Future<void> onPracticalCardTapped(WidgetRef ref) async {
-    /// TODO : XIMYA
-    /// 임시 코드
-
-    final room = ChatRoomEntity.generateResumeInterview(
-      qnas: tempResumeQnaList,
-    );
-
-    final route = ChatPageRoute(roomId: room.id, type: room.type);
-    route.updateArg(room: room);
-    route.push(ref.context);
-    return;
-
     await EasyLoading.show();
 
     final hasNotPracticalInterviewRecord =
@@ -90,4 +79,26 @@ mixin class HomeEvent {
     ref.invalidate(userTopicsProvider);
     SplashRoute().go(ref.context);
   }
+
+  ///
+  ///
+  ///
+  void routeToResumeChatList(WidgetRef ref) {
+    /// TODO : XIMYA
+    /// 임시 코드
+
+    final room = ChatRoomEntity.generateResumeInterview(
+      qnas: tempResumeQnaList,
+    );
+
+    final route = ChatPageRoute(roomId: room.id, type: room.type);
+    route.updateArg(room: room);
+    route.go(ref.context);
+    return;
+  }
+
+  ///
+  /// 이력서 채팅 면접 페이지로 이동
+  ///
+  void routeToResumeInterviewChat(WidgetRef ref) {}
 }

--- a/lib/presentation/pages/home/home_event.dart
+++ b/lib/presentation/pages/home/home_event.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/router/router.dart';
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/features/chat/chat.dart';
+import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/presentation/pages/interview/chat_list/providers/practical_chat_room_list_provider.dart';
 import 'package:techtalk/presentation/providers/main_bottom_navigation_provider.dart';
 import 'package:techtalk/presentation/providers/system/notification_status_provider.dart';
@@ -26,10 +27,8 @@ mixin class HomeEvent {
     /// TODO : XIMYA
     /// 임시 코드
 
-    final room = ChatRoomEntity.random(
-      type: InterviewType.resume,
-      topics: [],
-      questionCount: 8,
+    final room = ChatRoomEntity.generateResumeInterview(
+      qnas: tempResumeQnaList,
     );
 
     final route = ChatPageRoute(roomId: room.id, type: room.type);

--- a/lib/presentation/pages/home/home_event.dart
+++ b/lib/presentation/pages/home/home_event.dart
@@ -45,16 +45,18 @@ mixin class HomeEvent {
     if (hasNotPracticalInterviewRecord) {
       final chatRooms = await ref.read(practicalChatRoomListProvider.future);
       if (chatRooms.isEmpty) {
-        routeToTopicSelectPage(ref.context, type: InterviewType.practical);
+        routeToTopicSelectPage(ref.context,
+            type: InterviewType.commonPracticalTopic);
       } else {
         routeToChatListPage(ref.context,
-            type: InterviewType.practical, rooms: chatRooms);
+            type: InterviewType.commonPracticalTopic, rooms: chatRooms);
         unawaited(ref
             .read(userInfoProvider.notifier)
             .storeUserPracticalRecordExistInfo());
       }
     } else {
-      routeToChatListPage(ref.context, type: InterviewType.practical);
+      routeToChatListPage(ref.context,
+          type: InterviewType.commonPracticalTopic);
     }
 
     unawaited(EasyLoading.dismiss());

--- a/lib/presentation/pages/home/home_event.dart
+++ b/lib/presentation/pages/home/home_event.dart
@@ -23,6 +23,20 @@ mixin class HomeEvent {
   /// 실전 면접 기록 여부에 따라 라우팅을 다르게 진행
   ///
   Future<void> onPracticalCardTapped(WidgetRef ref) async {
+    /// TODO : XIMYA
+    /// 임시 코드
+
+    final room = ChatRoomEntity.random(
+      type: InterviewType.resume,
+      topics: [],
+      questionCount: 8,
+    );
+
+    final route = ChatPageRoute(roomId: room.id, type: room.type);
+    route.updateArg(room: room);
+    route.push(ref.context);
+    return;
+
     await EasyLoading.show();
 
     final hasNotPracticalInterviewRecord =

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -1,22 +1,15 @@
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:permission_handler/permission_handler.dart';
-import 'package:rxdart/subjects.dart';
-import 'package:techtalk/app/localization/app_locale.dart';
-import 'package:techtalk/app/localization/localization_enum.dart';
 import 'package:techtalk/app/style/app_color.dart';
 import 'package:techtalk/core/index.dart';
-import 'package:techtalk/features/chat/chat.dart';
-import 'package:techtalk/features/topic/topic.dart';
 import 'package:techtalk/presentation/pages/home/home_event.dart';
 import 'package:techtalk/presentation/pages/home/widgets/cheer_up_message_card.dart';
 import 'package:techtalk/presentation/pages/home/widgets/home_state.dart';
 import 'package:techtalk/presentation/pages/home/widgets/practical_interview_card.dart';
+import 'package:techtalk/presentation/pages/home/widgets/resume_interview_card.dart';
 import 'package:techtalk/presentation/pages/home/widgets/single_topic_interview_card.dart';
 import 'package:techtalk/presentation/widgets/base/base_page.dart';
 import 'package:techtalk/presentation/widgets/base/controller_holder.dart';
@@ -47,6 +40,8 @@ class HomePage extends BasePage with HomeState, HomeEvent {
             padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
             children: const [
               CheerUpMessageCard(),
+              Gap(16),
+              ResumeInterviewCard(),
               Gap(16),
               PracticalInterviewCard(),
               Gap(16),

--- a/lib/presentation/pages/home/widgets/interview_indicator_card.dart
+++ b/lib/presentation/pages/home/widgets/interview_indicator_card.dart
@@ -1,0 +1,82 @@
+import 'package:bounce_tapper/bounce_tapper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:techtalk/app/style/app_color.dart';
+import 'package:techtalk/app/style/app_text_style.dart';
+import 'package:techtalk/core/constants/assets.dart';
+import 'package:techtalk/presentation/widgets/common/indicator/new_badge.dart';
+
+///
+/// 홈 영역에서 사용되는 면접 타입별 카드 뷰
+///
+class InterviewIndicatorCard extends StatelessWidget {
+  const InterviewIndicatorCard({
+    super.key,
+    required this.title,
+    this.subDescription,
+    required this.onCardTapped,
+    this.showNewBadge = false,
+    this.onPlusSuffixedBtnTapped,
+  });
+
+  final String title;
+  final String? subDescription;
+  final VoidCallback onCardTapped;
+  final VoidCallback? onPlusSuffixedBtnTapped;
+  final bool showNewBadge;
+
+  @override
+  Widget build(BuildContext context) {
+    return BounceTapper(
+      onTap: onCardTapped,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(24, 12, 0, 12),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: AppColor.of.white,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      title,
+                      style: AppTextStyle.headline2.copyWith(
+                        color: AppColor.of.brand3,
+                      ),
+                    ),
+                    if (showNewBadge)
+                      const NewBadge(
+                        margin: EdgeInsets.only(left: 6),
+                      )
+                  ],
+                ),
+                BounceTapper(
+                  highlightColor: Colors.transparent,
+                  onTap: () {
+                    onPlusSuffixedBtnTapped?.call();
+                  },
+                  child: SvgPicture.asset(Assets.iconsRoundBlueCircle),
+                ),
+              ],
+            ),
+            if (subDescription != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12, right: 24),
+                child: Text(
+                  subDescription!,
+                  style: AppTextStyle.body1.copyWith(
+                    color: AppColor.of.gray3,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/home/widgets/practical_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/practical_interview_card.dart
@@ -9,59 +9,27 @@ import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/presentation/pages/home/home_event.dart';
 import 'package:techtalk/presentation/pages/home/widgets/home_state.dart';
+import 'package:techtalk/presentation/pages/home/widgets/interview_indicator_card.dart';
 
 class PracticalInterviewCard extends ConsumerWidget with HomeState, HomeEvent {
   const PracticalInterviewCard({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return BounceTapper(
-      onTap: () => onPracticalCardTapped(ref),
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(24, 12, 0, 12),
-        decoration: BoxDecoration(
-          color: AppColor.of.brand1,
-          borderRadius: BorderRadius.circular(16),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: Text(
-                    tr(LocaleKeys.home_practicalInterview),
-                    style: AppTextStyle.headline2.copyWith(
-                      color: AppColor.of.brand3,
-                    ),
-                  ),
-                ),
-                BounceTapper(
-                  highlightColor: Colors.transparent,
-                  onTap: () {
-                    routeToTopicSelectPage(
-                      context,
-                      type: InterviewType.commonPracticalTopic,
-                    );
-                  },
-                  child: SvgPicture.asset(Assets.iconsRoundBlueCircle),
-                ),
-              ],
-            ),
-            if (!(user(ref)?.hasPracticalInterviewRecord ?? false))
-              Padding(
-                padding: const EdgeInsets.only(bottom: 12, right: 24),
-                child: Text(
-                  tr(LocaleKeys.home_practicalInterviewDesc),
-                  style: AppTextStyle.body1.copyWith(
-                    color: AppColor.of.gray3,
-                  ),
-                ),
-              ),
-          ],
-        ),
-      ),
+    return InterviewIndicatorCard(
+      title: tr(LocaleKeys.home_practicalInterview),
+      subDescription: !(user(ref)?.hasPracticalInterviewRecord ?? false)
+          ? tr(LocaleKeys.home_practicalInterviewDesc)
+          : null,
+      onCardTapped: () {
+        onPracticalCardTapped(ref);
+      },
+      onPlusSuffixedBtnTapped: () {
+        routeToTopicSelectPage(
+          context,
+          type: InterviewType.commonPracticalTopic,
+        );
+      },
     );
   }
 }

--- a/lib/presentation/pages/home/widgets/practical_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/practical_interview_card.dart
@@ -42,7 +42,7 @@ class PracticalInterviewCard extends ConsumerWidget with HomeState, HomeEvent {
                   onTap: () {
                     routeToTopicSelectPage(
                       context,
-                      type: InterviewType.practical,
+                      type: InterviewType.commonPracticalTopic,
                     );
                   },
                   child: SvgPicture.asset(Assets.iconsRoundBlueCircle),

--- a/lib/presentation/pages/home/widgets/resume_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/resume_interview_card.dart
@@ -1,16 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/features/chat/chat.dart';
+import 'package:techtalk/presentation/pages/home/home_event.dart';
 import 'package:techtalk/presentation/pages/home/widgets/interview_indicator_card.dart';
 
-class ResumeInterviewCard extends ConsumerWidget {
+class ResumeInterviewCard extends ConsumerWidget with HomeEvent {
   const ResumeInterviewCard({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return InterviewIndicatorCard(
       title: '이력서 면접',
-      onCardTapped: () {},
-      onPlusSuffixedBtnTapped: () {},
+      onCardTapped: () {
+        routeToResumeChatList(ref);
+      },
+      onPlusSuffixedBtnTapped: () {
+        routeToChatListPage(context, type: InterviewType.resume);
+      },
       showNewBadge: true,
     );
   }

--- a/lib/presentation/pages/home/widgets/resume_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/resume_interview_card.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:techtalk/presentation/pages/home/widgets/interview_indicator_card.dart';
+
+class ResumeInterviewCard extends ConsumerWidget {
+  const ResumeInterviewCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return InterviewIndicatorCard(
+      title: '이력서 면접',
+      onCardTapped: () {},
+      onPlusSuffixedBtnTapped: () {},
+      showNewBadge: true,
+    );
+  }
+}

--- a/lib/presentation/pages/home/widgets/single_topic_interview_card.dart
+++ b/lib/presentation/pages/home/widgets/single_topic_interview_card.dart
@@ -45,7 +45,7 @@ class SingleTopicInterviewCard extends ConsumerWidget
                   onTap: () {
                     routeToTopicSelectPage(
                       context,
-                      type: InterviewType.singleTopic,
+                      type: InterviewType.commonSingleTopic,
                     );
                   },
                   child: SvgPicture.asset(Assets.iconsRoundBlueCircle),
@@ -97,7 +97,7 @@ class SingleTopicInterviewCard extends ConsumerWidget
           onTap: () {
             routeToChatListPage(
               context,
-              type: InterviewType.singleTopic,
+              type: InterviewType.commonSingleTopic,
               topicId: topic.id,
             );
           },
@@ -146,7 +146,7 @@ class SingleTopicInterviewCard extends ConsumerWidget
                       await Future.delayed(const Duration(milliseconds: 200));
                       routeToChatListPage(
                         context,
-                        type: InterviewType.singleTopic,
+                        type: InterviewType.commonSingleTopic,
                         topicId: topic.id,
                       );
                     },

--- a/lib/presentation/pages/interview/chat/chat_event.dart
+++ b/lib/presentation/pages/interview/chat/chat_event.dart
@@ -312,7 +312,7 @@ mixin class ChatEvent {
   ///
   void startRelatedNewTopicInterview(WidgetRef ref,
       {required TopicEntity targetTopic}) {
-    const type = InterviewType.singleTopic;
+    const type = InterviewType.commonSingleTopic;
 
     /// 메인까지 pop
     GoRouter.of(ref.context).popUntilPath(MainRoute.path);

--- a/lib/presentation/pages/interview/chat/chat_page.dart
+++ b/lib/presentation/pages/interview/chat/chat_page.dart
@@ -1,4 +1,3 @@
-import 'package:bounce_tapper/bounce_tapper.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +10,6 @@ import 'package:techtalk/core/index.dart';
 import 'package:techtalk/presentation/pages/interview/chat/chat_event.dart';
 import 'package:techtalk/presentation/pages/interview/chat/chat_state.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart';
-import 'package:techtalk/presentation/pages/interview/chat/widgets/interview_result/interview_result_dialog.dart';
 import 'package:techtalk/presentation/pages/interview/chat/widgets/interview_tab_view/interview_tab_view.dart';
 import 'package:techtalk/presentation/pages/interview/chat/widgets/qna_tab_view.dart';
 import 'package:techtalk/presentation/providers/user/user_info_provider.dart';

--- a/lib/presentation/pages/interview/chat/chat_page.dart
+++ b/lib/presentation/pages/interview/chat/chat_page.dart
@@ -22,6 +22,8 @@ part 'widgets/chat_page_scaffold.dart';
 
 part 'widgets/chat_page_app_bar.p.dart';
 
+part 'widgets/chat_page_watch_view.p.dart';
+
 class ChatPage extends BasePage with ChatEvent, ChatState {
   const ChatPage({Key? key}) : super(key: key);
 
@@ -33,6 +35,7 @@ class ChatPage extends BasePage with ChatEvent, ChatState {
       chatTabView: const InterviewTabView(),
       summaryTabView: const QnaTabView(),
       tabController: tabController,
+      watchView: const _WatchView(),
     );
   }
 

--- a/lib/presentation/pages/interview/chat/chat_state.dart
+++ b/lib/presentation/pages/interview/chat/chat_state.dart
@@ -144,9 +144,13 @@ mixin class ChatState {
   ///
   /// 현재 선택된 주제와 관련된 주제 (여러개 중 하나를 랜덤으로 추출)
   ///
-  TopicEntity randomRelatedTopicName(WidgetRef ref) {
-    final relatedTopics =
-        ref.read(selectedChatRoomProvider).topics.first.relatedSkillIds;
+  TopicEntity? randomRelatedTopicName(WidgetRef ref) {
+    final room = ref.read(selectedChatRoomProvider);
+
+    //// 단골 면접 질문 타입이 아닌 경우 리턴
+    if (!room.type.isCommonQuestionType) return null;
+
+    final relatedTopics = room.topics.first.relatedSkillIds;
 
     final math.Random random = math.Random();
     final int randomIndex = random.nextInt(relatedTopics.length);

--- a/lib/presentation/pages/interview/chat/chat_state.dart
+++ b/lib/presentation/pages/interview/chat/chat_state.dart
@@ -56,6 +56,11 @@ mixin class ChatState {
   ChatRoomEntity room(WidgetRef ref) => ref.watch(selectedChatRoomProvider);
 
   ///
+  /// 채팅방 (Read)
+  ///
+  ChatRoomEntity readRoom(WidgetRef ref) => ref.read(selectedChatRoomProvider);
+
+  ///
   /// 인터뷰 진행 상태
   ///
   InterviewProgress interviewProgressState(WidgetRef ref) =>

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_internal_event.p.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_internal_event.p.dart
@@ -3,7 +3,7 @@ part of 'chat_message_history_provider.dart';
 ///
 /// 단골질문 관련 provider event
 ///
-extension CommonTypeChatMessageHistory on ChatMessageHistory {
+extension ChatMessageHistoryInternalEvent on ChatMessageHistory {
   ///
   /// 꼬리질문 생성
   ///
@@ -143,85 +143,6 @@ extension CommonTypeChatMessageHistory on ChatMessageHistory {
     await ref.read(chatQnasProvider.notifier).updateState(resolvedAnsweredChat);
 
     return resolvedAnsweredChat;
-  }
-
-  ///
-  /// 초기 인트로 메시지와
-  /// 처음으로 질문을 제시
-  ///
-  Future<void> _showIntroAndQuestionMessages() async {
-    final room = ref.read(selectedChatRoomProvider);
-
-    final nickname = ref.watch(userInfoProvider).requireValue!.nickname!;
-    final firstQna = _getNewQna()!;
-    final String introMessage;
-
-    if (room.type.isSingleTopic) {
-      introMessage = rootNavigatorKey.currentContext!.tr(
-        LocaleKeys.undefined_greetingMessageSingleTopic,
-        namedArgs: {
-          'nickname': nickname,
-          'topic': room.topics.first.text,
-        },
-      );
-    } else {
-      introMessage = rootNavigatorKey.currentContext!.tr(
-        LocaleKeys.undefined_greetingMessageMultipleTopics,
-        namedArgs: {
-          'nickname': nickname,
-          'firstTopic':
-              StoredTopics.getById(firstQna.qna.id.getFirstPartOfSpliited).text,
-        },
-      );
-    }
-
-    final introChat = GuideChatEntity.createStatic(
-      message: introMessage,
-      timestamp: DateTime.timestamp(),
-    );
-
-    final firstQuestionChat = QuestionChatEntity.createStatic(
-      qnaId: firstQna.qna.id,
-      rootQnaId: firstQna.qna.id,
-      message: firstQna.qna.question,
-      timestamp: DateTime.timestamp(),
-    );
-
-    unawaited(
-      Future.wait(
-        [
-          createChatRoomUseCase(
-            room: ref.read(selectedChatRoomProvider),
-            messages: [firstQuestionChat, introChat],
-            qnas: ref.read(chatQnasProvider).requireValue,
-          ).then(
-            (_) {
-              ref
-                  .read(selectedChatRoomProvider.notifier)
-                  .updateInitialInfo(firstQuestionChat);
-            },
-          ),
-          showMessage(
-            message: introChat.overwriteToStream(),
-            onDone: () {
-              showMessage(
-                message: firstQuestionChat.overwriteToStream(),
-                onDone: () {
-                  ref
-                      .read(userInfoProvider.notifier)
-                      .updateTopicRecordsOnCondition(room.topics);
-                  if (room.type.isPractical) {
-                    ref
-                        .read(userInfoProvider.notifier)
-                        .storeUserPracticalRecordExistInfo();
-                  }
-                },
-              );
-            },
-          ),
-        ],
-      ),
-    );
   }
 
   ///

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
@@ -37,37 +37,38 @@ class ChatMessageHistory extends _$ChatMessageHistory {
   FutureOr<List<BaseChatEntity>> build() async {
     final room = ref.read(selectedChatRoomProvider);
 
-    if (room.type.isResume) {
-      await _showResumeTypeIntroMessages();
-      return [];
-    } else {
-      // 단골 질문 (주제별, 실전형)
-      final getChatList = switch (room.progressState) {
-        ChatRoomProgress.initial => () async {
-            await _showIntroAndQuestionMessages();
+    // 단골 질문 (주제별, 실전형)
+    final getChatList = switch (room.progressState) {
+      ChatRoomProgress.initial => () async {
+          await room.type.typedBranch(
+            common: (_) async {
+              await _showIntroAndQuestionMessages();
+            },
+            resume: (_) async {
+              await _showResumeTypeIntroMessages();
+            },
+          );
 
-            return <BaseChatEntity>[];
-          },
-        ChatRoomProgress.ongoing || ChatRoomProgress.completed => () async {
-            final response = await getChatMessageHistoryUseCase(room.id);
-            return response.fold(
-              onSuccess: (chatCollection) {
-                ref
-                    .read(chatQnasProvider.notifier)
-                    .arrangeQnasInOrder(chatCollection.progressQnaIds);
-                return chatCollection.chatHistories;
-              },
-              onFailure: (e) {
-                log(e.toString());
+          return <BaseChatEntity>[];
+        },
+      ChatRoomProgress.ongoing || ChatRoomProgress.completed => () async {
+          final response = await getChatMessageHistoryUseCase(room.id);
+          return response.fold(
+            onSuccess: (chatCollection) {
+              ref
+                  .read(chatQnasProvider.notifier)
+                  .arrangeQnasInOrder(chatCollection.progressQnaIds);
+              return chatCollection.chatHistories;
+            },
+            onFailure: (e) {
+              log(e.toString());
 
-                throw e;
-              },
-            );
-          },
-      };
-
-      return getChatList();
-    }
+              throw e;
+            },
+          );
+        },
+    };
+    return getChatList();
   }
 
   ///

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
@@ -38,6 +38,7 @@ class ChatMessageHistory extends _$ChatMessageHistory {
     final room = ref.read(selectedChatRoomProvider);
 
     if (room.type.isResume) {
+      await _showResumeTypeIntroMessages();
       return [];
     } else {
       // 단골 질문 (주제별, 실전형)
@@ -129,6 +130,7 @@ class ChatMessageHistory extends _$ChatMessageHistory {
       (
         chatHistory: chatHistory,
         qna: rootQna,
+        interviewType: room.type,
         userName: ref.read(userInfoProvider).requireValue!.nickname!,
         onError: _onAiFeedbackErrorOccured,
         checkAnswer: ({required AnswerState answerState}) async {
@@ -299,24 +301,6 @@ class ChatMessageHistory extends _$ChatMessageHistory {
         rootQnaId: rootQna.qna.id,
       ),
     );
-
-    // await response.fold(
-    //   onSuccess: (feedbackStreamedChat) async {
-    //     /// 3) 유저 답변에 대한 피드백 채팅 전달
-    //     await showMessage(
-    //       message: FeedbackChatEntity(
-    //         message: feedbackStreamedChat,
-    //         qnaId: rootQna.qna.id,
-    //         rootQnaId:  rootQna.qna.id,
-    //       ),
-    //     );
-    //   },
-    //   onFailure: (e) {
-    //     _rollbackToPreviousChatStep();
-    //     SnackBarService.showSnackBar(
-    //         '정답 여부를 판별하는 과정에서 오류가 발생했습니다. 잠시후 다시 시도해주세요.');
-    //   },
-    // );
   }
 
   ///

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
@@ -13,17 +13,15 @@ import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/entities/feedback_response_entity.dart';
 import 'package:techtalk/features/chat/use_cases/set_ai_follow_up_question_use_case.dart';
-import 'package:techtalk/features/topic/repositories/entities/common_qna_entity.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/chat_qnas_provider.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/is_follow_up_process_active_provider.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart';
 import 'package:techtalk/presentation/providers/user/user_info_provider.dart';
 import 'package:uuid/uuid.dart';
 
-part 'common_type_chat_message_history.dart';
-
+part 'chat_message_history_internal_event.p.dart';
 part 'resume_type_chat_message_history_internal_event.p.dart';
-
+part 'common_type_chat_message_history_internal_event.p.dart';
 part 'chat_message_history_provider.g.dart';
 
 @riverpod
@@ -42,7 +40,7 @@ class ChatMessageHistory extends _$ChatMessageHistory {
       ChatRoomProgress.initial => () async {
           await room.type.typedBranch(
             common: (_) async {
-              await _showIntroAndQuestionMessages();
+              await _showIntroAndCommonQuestionMessages();
             },
             resume: (_) async {
               await _showResumeTypeIntroMessages();
@@ -324,15 +322,5 @@ class ChatMessageHistory extends _$ChatMessageHistory {
     }
 
     return false;
-  }
-
-  CommonQnaEntity getCurrentCommonQna() {
-    final targetQuestion = state.requireValue
-        .firstWhere((chat) => chat is QuestionChatEntity) as QuestionChatEntity;
-
-    return (ref
-        .read(chatQnasProvider.notifier)
-        .getCommonQnaById(targetQuestion.qnaId)
-        .qna) as CommonQnaEntity;
   }
 }

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
@@ -20,7 +20,8 @@ import 'package:techtalk/presentation/pages/interview/chat/providers/selected_ch
 import 'package:techtalk/presentation/providers/user/user_info_provider.dart';
 import 'package:uuid/uuid.dart';
 
-part 'chat_message_history_internal_event.dart';
+part 'common_type_chat_message_history.dart';
+part 'resume_type_chat_message_history_internal_event.p.dart';
 
 part 'chat_message_history_provider.g.dart';
 
@@ -34,31 +35,37 @@ class ChatMessageHistory extends _$ChatMessageHistory {
   @override
   FutureOr<List<BaseChatEntity>> build() async {
     final room = ref.read(selectedChatRoomProvider);
-    final getChatList = switch (room.progressState) {
-      ChatRoomProgress.initial => () async {
-          await _showIntroAndQuestionMessages();
 
-          return <BaseChatEntity>[];
-        },
-      ChatRoomProgress.ongoing || ChatRoomProgress.completed => () async {
-          final response = await getChatMessageHistoryUseCase(room.id);
-          return response.fold(
-            onSuccess: (chatCollection) {
-              ref
-                  .read(chatQnasProvider.notifier)
-                  .arrangeQnasInOrder(chatCollection.progressQnaIds);
-              return chatCollection.chatHistories;
-            },
-            onFailure: (e) {
-              log(e.toString());
+    if (room.type.isResume) {
+      return [];
+    } else {
+      // 단골 질문 (주제별, 실전형)
+      final getChatList = switch (room.progressState) {
+        ChatRoomProgress.initial => () async {
+            await _showIntroAndQuestionMessages();
 
-              throw e;
-            },
-          );
-        },
-    };
+            return <BaseChatEntity>[];
+          },
+        ChatRoomProgress.ongoing || ChatRoomProgress.completed => () async {
+            final response = await getChatMessageHistoryUseCase(room.id);
+            return response.fold(
+              onSuccess: (chatCollection) {
+                ref
+                    .read(chatQnasProvider.notifier)
+                    .arrangeQnasInOrder(chatCollection.progressQnaIds);
+                return chatCollection.chatHistories;
+              },
+              onFailure: (e) {
+                log(e.toString());
 
-    return getChatList();
+                throw e;
+              },
+            );
+          },
+      };
+
+      return getChatList();
+    }
   }
 
   ///

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.dart
@@ -21,6 +21,7 @@ import 'package:techtalk/presentation/providers/user/user_info_provider.dart';
 import 'package:uuid/uuid.dart';
 
 part 'common_type_chat_message_history.dart';
+
 part 'resume_type_chat_message_history_internal_event.p.dart';
 
 part 'chat_message_history_provider.g.dart';
@@ -120,7 +121,7 @@ class ChatMessageHistory extends _$ChatMessageHistory {
 
     final rootQna = ref
         .read(chatQnasProvider.notifier)
-        .getQnaById(userAnswer.rootQnaId ?? userAnswer.qnaId);
+        .getCommonQnaById(userAnswer.rootQnaId ?? userAnswer.qnaId);
 
     isFollowUpProcessActive = Completer<bool>();
 
@@ -340,13 +341,13 @@ class ChatMessageHistory extends _$ChatMessageHistory {
     return false;
   }
 
-  CommonQnaEntity getCurrentQna() {
+  CommonQnaEntity getCurrentCommonQna() {
     final targetQuestion = state.requireValue
         .firstWhere((chat) => chat is QuestionChatEntity) as QuestionChatEntity;
 
-    return ref
+    return (ref
         .read(chatQnasProvider.notifier)
-        .getQnaById(targetQuestion.qnaId)
-        .qna;
+        .getCommonQnaById(targetQuestion.qnaId)
+        .qna) as CommonQnaEntity;
   }
 }

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.g.dart
@@ -7,7 +7,7 @@ part of 'chat_message_history_provider.dart';
 // **************************************************************************
 
 String _$chatMessageHistoryHash() =>
-    r'99eec3a0555e24941b1c647f289d9d44844f3c9a';
+    r'ecb7afc823e10ad97674ad35bf18f475d8ee3fc1';
 
 /// See also [ChatMessageHistory].
 @ProviderFor(ChatMessageHistory)

--- a/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_message_history_provider.g.dart
@@ -7,7 +7,7 @@ part of 'chat_message_history_provider.dart';
 // **************************************************************************
 
 String _$chatMessageHistoryHash() =>
-    r'c31e3d305edeb89bb82c366a7d46265ebd762f82';
+    r'99eec3a0555e24941b1c647f289d9d44844f3c9a';
 
 /// See also [ChatMessageHistory].
 @ProviderFor(ChatMessageHistory)

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
@@ -26,8 +26,11 @@ class ChatQnas extends _$ChatQnas {
       resume: (_) async {
         if (room.progressState.isInitial) {
           return room.qnas
-              .map((e) => ChatQnaEntity.fromResumeQnaEntityAtInitial(
-                  e as ResumeQnaEntity))
+              .map(
+                (e) => ChatQnaEntity.fromResumeQnaEntityAtInitial(
+                  e as ResumeQnaEntity,
+                ),
+              )
               .toList()
             ..shuffle();
         } else {

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
@@ -21,19 +21,26 @@ class ChatQnas extends _$ChatQnas {
   FutureOr<List<ChatQnaEntity>> build() async {
     final room = ref.read(selectedChatRoomProvider);
 
-    if (room.progressState.isInitial) {
-      final response = await getRandomQnaUseCase.call(room);
-      return response.fold(
-        onSuccess: (randomQnas) => randomQnas,
-        onFailure: (e) => _onError(e),
-      );
-    } else {
-      final response = await getChatQnasUseCase.call(room);
-      return response.fold(
-        onSuccess: (qnas) => qnas,
-        onFailure: (e) => _onError(e),
-      );
-    }
+    return room.type.typedBranch(
+      resume: (_) {
+        return [];
+      },
+      common: (_) async {
+        if (room.progressState.isInitial) {
+          final response = await getRandomQnaUseCase.call(room);
+          return response.fold(
+            onSuccess: (randomQnas) => randomQnas,
+            onFailure: (e) => _onError(e),
+          );
+        } else {
+          final response = await getChatQnasUseCase.call(room);
+          return response.fold(
+            onSuccess: (qnas) => qnas,
+            onFailure: (e) => _onError(e),
+          );
+        }
+      },
+    );
   }
 
   ///

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
@@ -53,7 +53,6 @@ class ChatQnas extends _$ChatQnas {
         : qnas[targetQnaIndex].copyWith(
             followUpQna: FollowUpQnaEntity.fromAnswerChatEntity(message));
 
-
     /// 일반 Qna
     if (isRootQna) {
       unawaited(
@@ -68,6 +67,7 @@ class ChatQnas extends _$ChatQnas {
         ),
       );
     }
+
     /// 꼬리 질문 Qna
     else {
       unawaited(
@@ -131,7 +131,7 @@ class ChatQnas extends _$ChatQnas {
   ///
   /// id값으로 Qna객체 반환
   ///
-  ChatQnaEntity getQnaById(String qnaId) {
+  ChatQnaEntity getCommonQnaById(String qnaId) {
     return state.requireValue.firstWhere((e) => e.qna.id == qnaId);
   }
 }

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
@@ -6,6 +6,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:techtalk/core/services/snack_bar_service.dart';
 import 'package:techtalk/features/chat/chat.dart';
 import 'package:techtalk/features/chat/repositories/entities/follow_up_qna_entity.dart';
+import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
 import 'package:techtalk/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart';
 import 'package:techtalk/presentation/pages/wrong_answer_note/providers/wrong_answers_provider.dart';
@@ -23,7 +24,10 @@ class ChatQnas extends _$ChatQnas {
 
     return room.type.typedBranch(
       resume: (_) {
-        return room.qnas.map((e) => ChatQnaEntity(qna: e)).toList()..shuffle();
+        return room.qnas
+            .map((e) => ChatQnaEntity.fromResumeQnaEntity(e as ResumeQnaEntity))
+            .toList()
+          ..shuffle();
       },
       common: (_) async {
         if (room.progressState.isInitial) {
@@ -47,6 +51,8 @@ class ChatQnas extends _$ChatQnas {
   /// qna 상태 업데이트
   ///
   Future<void> updateState(AnswerChatEntity message) async {
+    final room = ref.read(selectedChatRoomProvider);
+
     final qnas = state.requireValue;
     final targetQnaIndex =
         qnas.indexWhere((e) => e.qna.id == message.rootQnaId);
@@ -69,7 +75,7 @@ class ChatQnas extends _$ChatQnas {
               previous.removeAt(targetQnaIndex);
               return [...previous, resolvedQna];
             }),
-            _updateWrongAnswer(resolvedQna),
+            if (room.type.isCommonQuestionType) _updateWrongAnswer(resolvedQna),
           ],
         ),
       );

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
@@ -23,11 +23,20 @@ class ChatQnas extends _$ChatQnas {
     final room = ref.read(selectedChatRoomProvider);
 
     return room.type.typedBranch(
-      resume: (_) {
-        return room.qnas
-            .map((e) => ChatQnaEntity.fromResumeQnaEntity(e as ResumeQnaEntity))
-            .toList()
-          ..shuffle();
+      resume: (_) async {
+        if (room.progressState.isInitial) {
+          return room.qnas
+              .map((e) => ChatQnaEntity.fromResumeQnaEntityAtInitial(
+                  e as ResumeQnaEntity))
+              .toList()
+            ..shuffle();
+        } else {
+          final response = await getChatQnasUseCase.call(room);
+          return response.fold(
+            onSuccess: (qnas) => qnas,
+            onFailure: (e) => _onError(e),
+          );
+        }
       },
       common: (_) async {
         if (room.progressState.isInitial) {

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.dart
@@ -23,7 +23,7 @@ class ChatQnas extends _$ChatQnas {
 
     return room.type.typedBranch(
       resume: (_) {
-        return [];
+        return room.qnas.map((e) => ChatQnaEntity(qna: e)).toList()..shuffle();
       },
       common: (_) async {
         if (room.progressState.isInitial) {

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.g.dart
@@ -6,7 +6,7 @@ part of 'chat_qnas_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatQnasHash() => r'43edb4721661df0ad4c4096341f518b746974a2b';
+String _$chatQnasHash() => r'f2f515b63a79ea9c2235bb6d438009c4f116448d';
 
 ///
 /// 채팅 Qna 리스트

--- a/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/chat_qnas_provider.g.dart
@@ -6,7 +6,7 @@ part of 'chat_qnas_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatQnasHash() => r'4ca5e26d4967814c9f6460573826b51574a0ade5';
+String _$chatQnasHash() => r'43edb4721661df0ad4c4096341f518b746974a2b';
 
 ///
 /// 채팅 Qna 리스트

--- a/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
+++ b/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
@@ -29,6 +29,7 @@ extension CommonTypeChatMessageHistory on ChatMessageHistory {
     QuestionChatEntity? followUpQuestionChat;
 
     final response = SetAiFollowUpQuestionUseCase().call((
+      interviewType: ref.read(selectedChatRoomProvider).type,
       chatHistory: chatHistory,
       onFollowUpQuestionCompleted: ({required String followUpQuestion}) async {
         followUpQuestionChat = QuestionChatEntity.createStatic(

--- a/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
+++ b/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
@@ -246,7 +246,7 @@ extension CommonTypeChatMessageHistory on ChatMessageHistory {
   /// AI 응답 과정에서 에러 발생했을 때 실행하는 프로세스
   ///
   void _onAiFeedbackErrorOccured([Object? error, StackTrace? startTrace]) {
-    print('아랑이 : ${error}');
+    print('이그놀드 : ${error}');
     _rollbackToPreviousChatStep();
     SnackBarService.showSnackBar(
         tr(LocaleKeys.interview_aiFeedbackErrorOccured));

--- a/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
+++ b/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
@@ -1,6 +1,9 @@
 part of 'chat_message_history_provider.dart';
 
-extension ChatMessageHistoryInternalEvent on ChatMessageHistory {
+///
+/// 단골질문 관련 provider event
+///
+extension CommonTypeChatMessageHistory on ChatMessageHistory {
   ///
   /// 꼬리질문 생성
   ///
@@ -246,6 +249,7 @@ extension ChatMessageHistoryInternalEvent on ChatMessageHistory {
     _rollbackToPreviousChatStep();
     SnackBarService.showSnackBar(
         tr(LocaleKeys.interview_aiFeedbackErrorOccured));
+
     /// NOTE 임시 주석
     // await _rollbackToPreviousChatStep();
     // final context = rootNavigatorKey.currentContext!;

--- a/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
+++ b/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history.dart
@@ -246,6 +246,7 @@ extension CommonTypeChatMessageHistory on ChatMessageHistory {
   /// AI 응답 과정에서 에러 발생했을 때 실행하는 프로세스
   ///
   void _onAiFeedbackErrorOccured([Object? error, StackTrace? startTrace]) {
+    print('아랑이 : ${error}');
     _rollbackToPreviousChatStep();
     SnackBarService.showSnackBar(
         tr(LocaleKeys.interview_aiFeedbackErrorOccured));
@@ -271,10 +272,10 @@ extension CommonTypeChatMessageHistory on ChatMessageHistory {
     final chatList = state.requireValue;
 
     final targetIndex =
-        chatList.firstIndexWhereOrNull((chat) => chat.type.isQuestionMessage);
+        chatList.indexWhere((chat) => chat.type.isQuestionMessage);
 
     await update((previous) {
-      return [...chatList.sublist(targetIndex!, chatList.length - 1)];
+      return [...chatList.sublist(targetIndex, chatList.length)];
     });
   }
 }

--- a/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history_internal_event.p.dart
+++ b/lib/presentation/pages/interview/chat/providers/common_type_chat_message_history_internal_event.p.dart
@@ -1,19 +1,38 @@
 part of 'chat_message_history_provider.dart';
 
 ///
-/// 이력서(+포트폴리오) 면접
-/// [ChatMessageHistory] 내부 event + notifier 메소드
+/// 단골질문 > 내부 메소드
 ///
-extension ResumeTypeChatMessageHistoryInternalEvent on ChatMessageHistory {
+extension CommonTypeChatMessageHistoryInternalEvent on ChatMessageHistory {
   ///
   /// 초기 인트로 메시지와
   /// 처음으로 질문을 제시
   ///
-  Future<void> _showResumeTypeIntroMessages() async {
+  Future<void> _showIntroAndCommonQuestionMessages() async {
+    final room = ref.read(selectedChatRoomProvider);
+
     final nickname = ref.watch(userInfoProvider).requireValue!.nickname!;
     final firstQna = _getNewQna()!;
-    final String introMessage =
-        '안녕하세요 $nickname님 제출해주신 이력서, 포트폴리오 기반으로 면접 질문을 전달해 드릴게요';
+    final String introMessage;
+
+    if (room.type.isSingleTopic) {
+      introMessage = rootNavigatorKey.currentContext!.tr(
+        LocaleKeys.undefined_greetingMessageSingleTopic,
+        namedArgs: {
+          'nickname': nickname,
+          'topic': room.topics.first.text,
+        },
+      );
+    } else {
+      introMessage = rootNavigatorKey.currentContext!.tr(
+        LocaleKeys.undefined_greetingMessageMultipleTopics,
+        namedArgs: {
+          'nickname': nickname,
+          'firstTopic':
+              StoredTopics.getById(firstQna.qna.id.getFirstPartOfSpliited).text,
+        },
+      );
+    }
 
     final introChat = GuideChatEntity.createStatic(
       message: introMessage,
@@ -46,6 +65,16 @@ extension ResumeTypeChatMessageHistoryInternalEvent on ChatMessageHistory {
             onDone: () {
               showMessage(
                 message: firstQuestionChat.overwriteToStream(),
+                onDone: () {
+                  ref
+                      .read(userInfoProvider.notifier)
+                      .updateTopicRecordsOnCondition(room.topics);
+                  if (room.type.isPractical) {
+                    ref
+                        .read(userInfoProvider.notifier)
+                        .storeUserPracticalRecordExistInfo();
+                  }
+                },
               );
             },
           ),

--- a/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.g.dart
@@ -7,7 +7,7 @@ part of 'interview_progress_state_provider.dart';
 // **************************************************************************
 
 String _$interviewProgressStateHash() =>
-    r'54364773b771ae58710800e4202476a8532c01ee';
+    r'a1550bd53d9e7c22afcfeb39e7a840892b0d59af';
 
 /// See also [InterviewProgressState].
 @ProviderFor(InterviewProgressState)

--- a/lib/presentation/pages/interview/chat/providers/one_line_feedback_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/one_line_feedback_provider.dart
@@ -21,15 +21,18 @@ class OneLineFeedback extends _$OneLineFeedback {
       throw Exception();
     }
 
-    final interviewResult = ref.read(selectedChatRoomProvider).interviewResult;
+    final room = ref.read(selectedChatRoomProvider);
+
     final topics = ref.read(selectedChatRoomProvider).topics;
     final param = GetOneLineInterViewFeedbackParam(
-        chatHistory: chatHistory,
-        interviewResult: interviewResult,
-        topic: topics,
-        onError: (e, __) {
-          log('면접관 한줄 피드백 로드 실패 : $e');
-        });
+      chatHistory: chatHistory,
+      interviewResult: room.interviewResult,
+      interviewType: room.type,
+      topic: topics,
+      onError: (e, __) {
+        log('면접관 한줄 피드백 로드 실패 : $e');
+      },
+    );
     final result = getOneLineFeedbackUseCase.call(param);
     return result;
   }

--- a/lib/presentation/pages/interview/chat/providers/resume_type_chat_message_history_internal_event.p.dart
+++ b/lib/presentation/pages/interview/chat/providers/resume_type_chat_message_history_internal_event.p.dart
@@ -49,14 +49,14 @@ extension ResumeTypeChatMessageHistoryInternalEvent on ChatMessageHistory {
               showMessage(
                 message: firstQuestionChat.overwriteToStream(),
                 onDone: () {
-                  ref
-                      .read(userInfoProvider.notifier)
-                      .updateTopicRecordsOnCondition(room.topics);
-                  if (room.type.isPractical) {
-                    ref
-                        .read(userInfoProvider.notifier)
-                        .storeUserPracticalRecordExistInfo();
-                  }
+                  // ref
+                  //     .read(userInfoProvider.notifier)
+                  //     .updateTopicRecordsOnCondition(room.topics);
+                  // if (room.type.isPractical) {
+                  //   ref
+                  //       .read(userInfoProvider.notifier)
+                  //       .storeUserPracticalRecordExistInfo();
+                  // }
                 },
               );
             },

--- a/lib/presentation/pages/interview/chat/providers/resume_type_chat_message_history_internal_event.p.dart
+++ b/lib/presentation/pages/interview/chat/providers/resume_type_chat_message_history_internal_event.p.dart
@@ -1,0 +1,68 @@
+part of 'chat_message_history_provider.dart';
+
+///
+/// 이력서(+포트폴리오) 면접
+/// [ChatMessageHistory] 내부 event + notifier 메소드
+///
+extension ResumeTypeChatMessageHistoryInternalEvent on ChatMessageHistory {
+  ///
+  /// 초기 인트로 메시지와
+  /// 처음으로 질문을 제시
+  ///
+  Future<void> _showResumeTypeIntroMessages() async {
+    final room = ref.read(selectedChatRoomProvider);
+
+    final nickname = ref.watch(userInfoProvider).requireValue!.nickname!;
+    final firstQna = _getNewQna()!;
+    final String introMessage =
+        '안녕하세요 $nickname님 제출해주신 이력서, 포트폴리오 기반으로 면접 질문을 전달해 드릴게요';
+
+    final introChat = GuideChatEntity.createStatic(
+      message: introMessage,
+      timestamp: DateTime.timestamp(),
+    );
+
+    final firstQuestionChat = QuestionChatEntity.createStatic(
+      qnaId: firstQna.qna.id,
+      rootQnaId: firstQna.qna.id,
+      message: firstQna.qna.question,
+      timestamp: DateTime.timestamp(),
+    );
+
+    unawaited(
+      Future.wait(
+        [
+          createChatRoomUseCase(
+            room: ref.read(selectedChatRoomProvider),
+            messages: [firstQuestionChat, introChat],
+            qnas: ref.read(chatQnasProvider).requireValue,
+          ).then(
+            (_) {
+              ref
+                  .read(selectedChatRoomProvider.notifier)
+                  .updateInitialInfo(firstQuestionChat);
+            },
+          ),
+          showMessage(
+            message: introChat.overwriteToStream(),
+            onDone: () {
+              showMessage(
+                message: firstQuestionChat.overwriteToStream(),
+                onDone: () {
+                  ref
+                      .read(userInfoProvider.notifier)
+                      .updateTopicRecordsOnCondition(room.topics);
+                  if (room.type.isPractical) {
+                    ref
+                        .read(userInfoProvider.notifier)
+                        .storeUserPracticalRecordExistInfo();
+                  }
+                },
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart
@@ -59,6 +59,9 @@ class SelectedChatRoom extends _$SelectedChatRoom {
     );
 
     state = updatedRoom;
-    ref.read(interviewRoomsProvider.notifier).synchronizeRooms(updatedRoom);
+
+    if (ref.exists(interviewRoomsProvider)) {
+      ref.read(interviewRoomsProvider.notifier).synchronizeRooms(updatedRoom);
+    }
   }
 }

--- a/lib/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart
+++ b/lib/presentation/pages/interview/chat/providers/selected_chat_room_provider.dart
@@ -22,7 +22,6 @@ class SelectedChatRoom extends _$SelectedChatRoom {
     final updatedRoom = state.copyWith(
       lastChatDate: lastChat.timestamp,
       lastChatMessage: lastChat.message.value,
-      chatProgressState: ChatRoomProgress.ongoing,
     );
 
     state = updatedRoom;

--- a/lib/presentation/pages/interview/chat/providers/selected_chat_room_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/selected_chat_room_provider.g.dart
@@ -6,7 +6,7 @@ part of 'selected_chat_room_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$selectedChatRoomHash() => r'20cb4c5bce21b4d4b4d1cc5f3a5e91276f23efb4';
+String _$selectedChatRoomHash() => r'bb787205d0dd32fdc65aebaa2548fb2ef91e907b';
 
 /// See also [SelectedChatRoom].
 @ProviderFor(SelectedChatRoom)

--- a/lib/presentation/pages/interview/chat/widgets/chat_page_app_bar.p.dart
+++ b/lib/presentation/pages/interview/chat/widgets/chat_page_app_bar.p.dart
@@ -1,18 +1,25 @@
 part of '../chat_page.dart';
 
-class _AppBar extends ConsumerWidget
+class _AppBar extends HookConsumerWidget
     with ChatState, ChatEvent
     implements PreferredSizeWidget {
   const _AppBar({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final firstTopic = ref.watch(selectedChatRoomProvider).topics.first.text;
-    final otherTopicCount = room(ref).topics.length - 1;
+    String? appBarTitle = useMemoized(() {
+      if (room(ref).type.isResume) {
+        return '이력서 면접';
+      } else {
+        final firstTopic =
+            ref.watch(selectedChatRoomProvider).topics.first.text;
+        final otherTopicCount = room(ref).topics.length - 1;
+        return '$firstTopic${otherTopicCount > 0 ? ' ${tr(LocaleKeys.undefined_and)} $otherTopicCount' : ''}';
+      }
+    });
 
     return BackButtonAppBar(
-      title:
-          '$firstTopic${otherTopicCount > 0 ? ' ${tr(LocaleKeys.undefined_and)} $otherTopicCount' : ''}',
+      title: appBarTitle ?? '',
       onBackBtnTapped: () {
         onAppbarBackBtnTapped(ref);
       },

--- a/lib/presentation/pages/interview/chat/widgets/chat_page_scaffold.dart
+++ b/lib/presentation/pages/interview/chat/widgets/chat_page_scaffold.dart
@@ -6,10 +6,12 @@ class _Scaffold extends StatelessWidget {
     required this.chatTabView,
     required this.summaryTabView,
     required this.tabController,
+    required this.watchView,
   }) : super(key: key);
 
   final Widget chatTabView;
   final Widget summaryTabView;
+  final Widget watchView;
   final TabController tabController;
 
   @override
@@ -36,7 +38,9 @@ class _Scaffold extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(horizontal: 20),
                       controller: tabController,
                       tabs: [
-                       Tab(text: tr(LocaleKeys.common_interviewTerms_interview)),
+                        Tab(
+                            text:
+                                tr(LocaleKeys.common_interviewTerms_interview)),
                         Tab(text: tr(LocaleKeys.common_interviewTerms_qa)),
                       ],
                       indicator: UnderlineTabIndicator(
@@ -71,7 +75,8 @@ class _Scaffold extends StatelessWidget {
               summaryTabView,
             ],
           ),
-        )
+        ),
+        watchView,
       ],
     );
   }

--- a/lib/presentation/pages/interview/chat/widgets/chat_page_watch_view.p.dart
+++ b/lib/presentation/pages/interview/chat/widgets/chat_page_watch_view.p.dart
@@ -1,0 +1,11 @@
+part of '../chat_page.dart';
+
+class _WatchView extends ConsumerWidget {
+  const _WatchView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(selectedChatRoomProvider);
+    return const EmptyBox();
+  }
+}

--- a/lib/presentation/pages/interview/chat/widgets/interview_result/interview_induction_view.p.dart
+++ b/lib/presentation/pages/interview/chat/widgets/interview_result/interview_induction_view.p.dart
@@ -27,73 +27,73 @@ class _InterviewInductionView extends HookConsumerWidget
       child: Column(
         children: <Widget>[
           /// LEADING
-          InterviewType.branch(
-            targetType: room(ref).type,
-            singleTopic: (_) => RichText(
-              text: TextSpan(
-                children: [
-                  TextSpan(
-                    text: tr(LocaleKeys.interview_suggestSimilarTopicsLeading),
-                  ),
-                  TextSpan(
-                    text: relatedTopic.text,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.w700,
+          room(ref).type.branch(
+                singleTopic: (_) => RichText(
+                  text: TextSpan(
+                    children: [
+                      TextSpan(
+                        text: tr(
+                            LocaleKeys.interview_suggestSimilarTopicsLeading),
+                      ),
+                      TextSpan(
+                        text: relatedTopic.text,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      TextSpan(
+                        text: tr(LocaleKeys.interview_suggestSimilarTopicsEnd),
+                      ),
+                    ],
+                    style: AppTextStyle.body1.copyWith(
+                      color: AppColor.of.gray6,
                     ),
                   ),
-                  TextSpan(
-                    text: tr(LocaleKeys.interview_suggestSimilarTopicsEnd),
-                  ),
-                ],
-                style: AppTextStyle.body1.copyWith(
-                  color: AppColor.of.gray6,
+                  textAlign: TextAlign.center,
+                ),
+                practical: (_) => Column(
+                  children: <Widget>[
+                    Text(
+                      tr(LocaleKeys.interview_tryRecap),
+                      maxLines: 2,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTextStyle.headline2,
+                    ),
+                    const Gap(8),
+                    Text(
+                      tr(LocaleKeys.interview_retryInterview),
+                      style: AppTextStyle.body3.copyWith(
+                        color: AppColor.of.gray4,
+                      ),
+                      maxLines: 2,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+                resume: (_) => Column(
+                  children: <Widget>[
+                    Text(
+                      '이력서를 점검하고\n다시 도전해 보세요',
+                      maxLines: 2,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTextStyle.headline2,
+                    ),
+                    const Gap(8),
+                    Text(
+                      '완성도를 높이면 더 구체적이고\n심층적인 질문을 받을 수 있어요',
+                      style: AppTextStyle.body3.copyWith(
+                        color: AppColor.of.gray4,
+                      ),
+                      maxLines: 2,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
                 ),
               ),
-              textAlign: TextAlign.center,
-            ),
-            practical: (_) => Column(
-              children: <Widget>[
-                Text(
-                  tr(LocaleKeys.interview_tryRecap),
-                  maxLines: 2,
-                  textAlign: TextAlign.center,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTextStyle.headline2,
-                ),
-                const Gap(8),
-                Text(
-                  tr(LocaleKeys.interview_retryInterview),
-                  style: AppTextStyle.body3.copyWith(
-                    color: AppColor.of.gray4,
-                  ),
-                  maxLines: 2,
-                  textAlign: TextAlign.center,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
-            resume: (_) => Column(
-              children: <Widget>[
-                Text(
-                  '이력서를 점검하고\n다시 도전해 보세요',
-                  maxLines: 2,
-                  textAlign: TextAlign.center,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTextStyle.headline2,
-                ),
-                const Gap(8),
-                Text(
-                  '완성도를 높이면 더 구체적이고\n심층적인 질문을 받을 수 있어요',
-                  style: AppTextStyle.body3.copyWith(
-                    color: AppColor.of.gray4,
-                  ),
-                  maxLines: 2,
-                  textAlign: TextAlign.center,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
-          ),
           const Gap(16),
 
           /// ILLUSTRATION
@@ -157,12 +157,12 @@ class _InterviewInductionView extends HookConsumerWidget
                       }
                     },
                     child: Text(
-                      InterviewType.branch(
-                        targetType: room(ref).type,
-                        singleTopic: (_) => tr(LocaleKeys.home_takeInterview),
-                        practical: (_) => tr(LocaleKeys.interview_tryAgain),
-                        resume: (_) => tr(LocaleKeys.interview_tryAgain),
-                      ),
+                      room(ref).type.branch(
+                            singleTopic: (_) =>
+                                tr(LocaleKeys.home_takeInterview),
+                            practical: (_) => tr(LocaleKeys.interview_tryAgain),
+                            resume: (_) => tr(LocaleKeys.interview_tryAgain),
+                          ),
                     ),
                   ),
                 ),

--- a/lib/presentation/pages/interview/chat/widgets/interview_result/interview_induction_view.p.dart
+++ b/lib/presentation/pages/interview/chat/widgets/interview_result/interview_induction_view.p.dart
@@ -7,6 +7,7 @@ class _InterviewInductionView extends HookConsumerWidget
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useAutomaticKeepAlive();
+
     final relatedTopic = useMemoized(() => randomRelatedTopicName(ref));
 
     return Container(
@@ -36,7 +37,7 @@ class _InterviewInductionView extends HookConsumerWidget
                             LocaleKeys.interview_suggestSimilarTopicsLeading),
                       ),
                       TextSpan(
-                        text: relatedTopic.text,
+                        text: relatedTopic?.text ?? '',
                         style: const TextStyle(
                           fontWeight: FontWeight.w700,
                         ),
@@ -149,12 +150,22 @@ class _InterviewInductionView extends HookConsumerWidget
                       ),
                     ),
                     onPressed: () {
-                      if (room(ref).type.isSingleTopic) {
-                        startRelatedNewTopicInterview(ref,
-                            targetTopic: relatedTopic);
-                      } else {
-                        retryThisInterview(ref);
-                      }
+                      room(ref).type.branch(
+                        singleTopic: (_) {
+                          startRelatedNewTopicInterview(
+                            ref,
+                            targetTopic: relatedTopic!,
+                          );
+                        },
+                        practical: (_) {
+                          retryThisInterview(ref);
+                        },
+                        resume: (_) {
+                          /// TODO : XIMYA
+                          /// 테스트 필요
+                          retryThisInterview(ref);
+                        },
+                      );
                     },
                     child: Text(
                       room(ref).type.branch(

--- a/lib/presentation/pages/interview/chat/widgets/qna_detail_box.dart
+++ b/lib/presentation/pages/interview/chat/widgets/qna_detail_box.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:gap/gap.dart';
+import 'package:techtalk/app/style/app_color.dart';
+import 'package:techtalk/app/style/app_text_style.dart';
+
+///
+/// ChatPage > QnaTabView > 문답 상세 항목을 나타내는 뷰
+///
+class QnaDetailBox extends StatelessWidget {
+  const QnaDetailBox({
+    super.key,
+    this.bgColor = const Color(0xFFF7F8FC), // [AppColor.of.brand5]
+    this.suffixedIconPath,
+    required this.title,
+    required this.descriptions,
+  });
+
+  final Color bgColor;
+  final String title;
+  final List<String> descriptions;
+  final String? suffixedIconPath; // title 영역 우측에 배치되는 아이콘
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 제목 텍스트
+          Row(
+            children: [
+              Text(
+                title,
+                style: AppTextStyle.body1,
+              ),
+              const Gap(2),
+              if (suffixedIconPath != null) SvgPicture.asset(suffixedIconPath!),
+            ],
+          ),
+          const Gap(6),
+          // 내용
+          ListView.separated(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: descriptions.length,
+            separatorBuilder: (_, __) => Divider(
+              thickness: 0.7,
+              color: AppColor.of.gray1,
+              height: 24,
+            ),
+            itemBuilder: (context, index) {
+              final item = descriptions[index];
+              return Text(
+                item,
+                style: AppTextStyle.body3,
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/interview/chat/widgets/qna_expansion_tile.dart
+++ b/lib/presentation/pages/interview/chat/widgets/qna_expansion_tile.dart
@@ -11,6 +11,7 @@ import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/repositories/entities/chat_qna_entity.dart';
 import 'package:techtalk/features/chat/repositories/enums/follow_up_status.enum.dart';
 import 'package:techtalk/features/chat/repositories/enums/interview_result.dart';
+import 'package:techtalk/features/topic/repositories/entities/common_qna_entity.dart';
 import 'package:techtalk/presentation/pages/interview/chat/chat_state.dart';
 import 'package:techtalk/presentation/widgets/common/indicator/response_indicator.dart';
 import 'package:techtalk/presentation/widgets/common/tile/flexible_expansion_tile.dart';
@@ -86,31 +87,40 @@ class QnAExpansionTile extends HookConsumerWidget with ChatState {
             ),
 
             /// 모범 답변
-            _buildAnswerContainer(
-              backgroundColor: AppColor.of.brand5,
-              title: tr(LocaleKeys.qa_modelAnswer),
-              children: List.generate(
-                item.qna.answers.length,
-                (index) => Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: Text(
-                        item.qna.answers[index],
-                        style: AppTextStyle.body3,
+            /// TODO: XIMYA
+            /// 예외처리 필요
+            /// 임시 로직임
+            if (item.qna.type.isCommon)
+              Builder(
+                builder: (context) {
+                  final targetQna = item.qna as CommonQnaEntity;
+                  return _buildAnswerContainer(
+                    backgroundColor: AppColor.of.brand5,
+                    title: tr(LocaleKeys.qa_modelAnswer),
+                    children: List.generate(
+                      targetQna.answers.length,
+                      (index) => Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: Text(
+                              targetQna.answers[index],
+                              style: AppTextStyle.body3,
+                            ),
+                          ),
+                          if (index != targetQna.answers.length - 1)
+                            Divider(
+                              thickness: 0.7,
+                              color: AppColor.of.gray1,
+                              height: 24,
+                            ),
+                        ],
                       ),
                     ),
-                    if (index != item.qna.answers.length - 1)
-                      Divider(
-                        thickness: 0.7,
-                        color: AppColor.of.gray1,
-                        height: 24,
-                      ),
-                  ],
-                ),
+                  );
+                },
               ),
-            ),
 
             // TODO : 꼬리질문 기능 구현시 적용할 예정
             if (item.followUpQna?.question != null)

--- a/lib/presentation/pages/interview/chat/widgets/qna_expansion_tile.dart
+++ b/lib/presentation/pages/interview/chat/widgets/qna_expansion_tile.dart
@@ -1,4 +1,3 @@
-import 'package:bounce_tapper/bounce_tapper.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -9,21 +8,31 @@ import 'package:techtalk/app/localization/locale_keys.g.dart';
 import 'package:techtalk/app/style/index.dart';
 import 'package:techtalk/core/index.dart';
 import 'package:techtalk/features/chat/repositories/entities/chat_qna_entity.dart';
+import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/features/chat/repositories/enums/follow_up_status.enum.dart';
 import 'package:techtalk/features/chat/repositories/enums/interview_result.dart';
 import 'package:techtalk/features/topic/repositories/entities/common_qna_entity.dart';
 import 'package:techtalk/presentation/pages/interview/chat/chat_state.dart';
+import 'package:techtalk/presentation/pages/interview/chat/widgets/qna_detail_box.dart';
+import 'package:techtalk/presentation/widgets/common/chip/resume_question_type_chip.dart';
 import 'package:techtalk/presentation/widgets/common/indicator/response_indicator.dart';
 import 'package:techtalk/presentation/widgets/common/tile/flexible_expansion_tile.dart';
 
-class QnAExpansionTile extends HookConsumerWidget with ChatState {
-  const QnAExpansionTile(this.item, {Key? key}) : super(key: key);
+class QnaExpansionTile extends HookConsumerWidget with ChatState {
+  const QnaExpansionTile(this.item, {Key? key}) : super(key: key);
 
   final ChatQnaEntity item;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isOpen = useState<bool>(false);
+
+    // readRoom(ref).type.typedBranch(
+    //       common: (_) {
+    //         item.qna
+    //       },
+    //       resume: (_) {},
+    //     );
 
     return FlexibleExpansionTile(
       isExpanded: isOpen,
@@ -37,17 +46,28 @@ class QnAExpansionTile extends HookConsumerWidget with ChatState {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               /// CORRECT WRONG INDICATOR
-
-              ResponseIndicator(
-                followupStatus: item.followUpQna != null
-                    ? FollowupStatus.yes
-                    : FollowupStatus.no,
-                chatResult: item.message!.answerState.isCorrect
-                    ? InterviewResult.pass
-                    : InterviewResult.failed,
-                text: item.message!.answerState.isCorrect
-                    ? context.tr(LocaleKeys.common_responseResult_correct)
-                    : context.tr(LocaleKeys.common_responseResult_incorrect),
+              Wrap(
+                children: [
+                  if (readRoom(ref).type.isResume)
+                    ResumeQuestionTypeChip(
+                      type: (item.qna as ResumeQnaEntity).questionType,
+                      margin: const EdgeInsets.only(
+                        right: 6,
+                      ),
+                    ),
+                  ResponseIndicator(
+                    followupStatus: item.followUpQna != null
+                        ? FollowupStatus.yes
+                        : FollowupStatus.no,
+                    chatResult: item.message!.answerState.isCorrect
+                        ? InterviewResult.pass
+                        : InterviewResult.failed,
+                    text: item.message!.answerState.isCorrect
+                        ? context.tr(LocaleKeys.common_responseResult_correct)
+                        : context
+                            .tr(LocaleKeys.common_responseResult_incorrect),
+                  ),
+                ],
               ),
               AnimatedRotation(
                 turns: isOpen.value ? 0 : 0.5,
@@ -75,107 +95,48 @@ class QnAExpansionTile extends HookConsumerWidget with ChatState {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             /// 내 답변
-            _buildAnswerContainer(
-              backgroundColor: AppColor.of.brand5,
+            QnaDetailBox(
               title: tr(LocaleKeys.qa_myAnswer),
-              children: [
-                Text(
-                  item.message!.message.value,
-                  style: AppTextStyle.body3,
-                ),
-              ],
+              descriptions: [item.message!.message.value],
             ),
 
-            /// 모범 답변
-            /// TODO: XIMYA
-            /// 예외처리 필요
-            /// 임시 로직임
+            /// 단골 질문 인터뷰
+            /// => 모범 답변
             if (item.qna.type.isCommon)
               Builder(
                 builder: (context) {
                   final targetQna = item.qna as CommonQnaEntity;
-                  return _buildAnswerContainer(
-                    backgroundColor: AppColor.of.brand5,
+                  return QnaDetailBox(
                     title: tr(LocaleKeys.qa_modelAnswer),
-                    children: List.generate(
-                      targetQna.answers.length,
-                      (index) => Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 8),
-                            child: Text(
-                              targetQna.answers[index],
-                              style: AppTextStyle.body3,
-                            ),
-                          ),
-                          if (index != targetQna.answers.length - 1)
-                            Divider(
-                              thickness: 0.7,
-                              color: AppColor.of.gray1,
-                              height: 24,
-                            ),
-                        ],
-                      ),
-                    ),
+                    descriptions: targetQna.answers,
+                  );
+                },
+              ),
+
+            /// 이력서 질문 일터뷰
+            /// => 평가 요소
+            if (item.qna.type.isResume)
+              Builder(
+                builder: (context) {
+                  final targetQna = item.qna as ResumeQnaEntity;
+                  return QnaDetailBox(
+                    /// TODO : XIMYA
+                    /// LOCALIZATION 처리 필요
+                    title: '평가요소',
+                    descriptions: [targetQna.evaluationPoint],
                   );
                 },
               ),
 
             // TODO : 꼬리질문 기능 구현시 적용할 예정
             if (item.followUpQna?.question != null)
-              _buildAnswerContainer(
-                backgroundColor: AppColor.of.purple1,
-                title: '꼬리 질문',
-                showIndicator: true,
-                children: [
-                  Text(
-                    item.followUpQna!.question!,
-                    style: AppTextStyle.body3,
-                  ),
-                ],
+              QnaDetailBox(
+                title: tr(LocaleKeys.interview_followUpQuestion),
+                descriptions: [item.followUpQna!.question!],
+                bgColor: AppColor.of.purple1,
               ),
           ],
         ),
-      ),
-    );
-  }
-
-  // 공통된 레이아웃 위젯
-  Widget _buildAnswerContainer({
-    required Color backgroundColor,
-    required String title,
-    required List<Widget> children,
-    bool showIndicator = false,
-    String? iconIndicatorPath,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      margin: const EdgeInsets.symmetric(vertical: 8),
-      width: double.infinity,
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 제목 텍스트
-          Row(
-            children: [
-              Text(
-                title,
-                style: AppTextStyle.body1,
-              ),
-              const Gap(2),
-              if (showIndicator)
-                SvgPicture.asset(iconIndicatorPath ?? Assets.iconsStarDeco),
-            ],
-          ),
-          const Gap(6),
-          // 내용
-          ...children,
-        ],
       ),
     );
   }

--- a/lib/presentation/pages/interview/chat/widgets/qna_tab_view.dart
+++ b/lib/presentation/pages/interview/chat/widgets/qna_tab_view.dart
@@ -72,7 +72,11 @@ class QnaTabView extends HookConsumerWidget with ChatState {
             height: ChatPage.tabViewHeight,
             child: const Center(
               child: ExceptionIndicator(
-                  subTitle: '다시 시도해주세요', title: '문답 내역을 불러오지 못했어요.'),
+                /// TODO : XIMYA
+                /// LOCALIZATION
+                subTitle: '다시 시도해주세요',
+                title: '문답 내역을 불러오지 못했어요.',
+              ),
             ),
           ),
           loading: () => SizedBox(

--- a/lib/presentation/pages/interview/chat/widgets/qna_tab_view.dart
+++ b/lib/presentation/pages/interview/chat/widgets/qna_tab_view.dart
@@ -64,7 +64,7 @@ class QnaTabView extends HookConsumerWidget with ChatState {
                 color: AppColor.of.gray2,
               ),
               itemBuilder: (context, index) {
-                return QnAExpansionTile(qnaList[index]);
+                return QnaExpansionTile(qnaList[index]);
               },
             );
           },

--- a/lib/presentation/pages/interview/chat_list/chat_list_event.dart
+++ b/lib/presentation/pages/interview/chat_list/chat_list_event.dart
@@ -21,7 +21,7 @@ mixin class ChatListEvent {
     WidgetRef ref, {
     required TopicEntity topic,
   }) {
-    const type = InterviewType.singleTopic;
+    const type = InterviewType.commonSingleTopic;
 
     final route = QuestionCountSelectPageRoute(
       type,
@@ -37,7 +37,7 @@ mixin class ChatListEvent {
   ///
   void routeToTopicSelectPage(WidgetRef ref) {
     InterviewTopicSelectRoute(
-      InterviewType.practical,
+      InterviewType.commonPracticalTopic,
     ).push(ref.context);
   }
 }

--- a/lib/presentation/pages/interview/chat_list/chat_list_page.dart
+++ b/lib/presentation/pages/interview/chat_list/chat_list_page.dart
@@ -74,7 +74,7 @@ class ChatListPage extends BasePage with ChatListState, ChatListEvent {
               case InterviewType.commonPracticalTopic:
                 routeToTopicSelectPage(ref);
               case InterviewType.resume:
-                throw Exception('타입을 지정해주어야 합니다');
+                throw Exception('타입을 지정해주어야 합니다1');
             }
           },
           height: 56,
@@ -101,7 +101,7 @@ class ChatListPage extends BasePage with ChatListState, ChatListEvent {
               ref.read(selectedChatRoomProvider).singleTopic.text,
           InterviewType.commonPracticalTopic =>
             tr(LocaleKeys.undefined_realWorldInterview),
-          InterviewType.resume => throw Exception('타입을 지정해주어야 합니다'),
+          InterviewType.resume => '',
         },
       );
 

--- a/lib/presentation/pages/interview/chat_list/chat_list_page.dart
+++ b/lib/presentation/pages/interview/chat_list/chat_list_page.dart
@@ -66,12 +66,12 @@ class ChatListPage extends BasePage with ChatListState, ChatListEvent {
         return MaterialButton(
           onPressed: () {
             switch (selectedInterviewType(ref)) {
-              case InterviewType.singleTopic:
+              case InterviewType.commonSingleTopic:
                 routeToQuestionCountSelectPage(
                   ref,
                   topic: selectedTopic(ref)!,
                 );
-              case InterviewType.practical:
+              case InterviewType.commonPracticalTopic:
                 routeToTopicSelectPage(ref);
               case InterviewType.resume:
                 throw Exception('타입을 지정해주어야 합니다');
@@ -97,9 +97,9 @@ class ChatListPage extends BasePage with ChatListState, ChatListEvent {
   PreferredSizeWidget? buildAppBar(BuildContext context, WidgetRef ref) =>
       BackButtonAppBar(
         title: switch (selectedInterviewType(ref)) {
-          InterviewType.singleTopic => selectedTopic(ref)?.text ??
+          InterviewType.commonSingleTopic => selectedTopic(ref)?.text ??
               ref.read(selectedChatRoomProvider).singleTopic.text,
-          InterviewType.practical =>
+          InterviewType.commonPracticalTopic =>
             tr(LocaleKeys.undefined_realWorldInterview),
           InterviewType.resume => throw Exception('타입을 지정해주어야 합니다'),
         },

--- a/lib/presentation/pages/interview/chat_list/local_widgets/chat_room_item_view.dart
+++ b/lib/presentation/pages/interview/chat_list/local_widgets/chat_room_item_view.dart
@@ -34,118 +34,121 @@ class ChatRoomItemView extends StatelessWidget with ChatListEvent {
   @override
   Widget build(BuildContext context) {
     if (isLoaded) {
-      return MaterialButton(
-        padding: const EdgeInsets.symmetric(horizontal: 16) +
-            const EdgeInsets.only(top: 24, bottom: 24),
-        onPressed: () {
+      return BounceTapper(
+        onTap: () {
           routeToChatPage(
             context,
             room: item!,
           );
         },
-        child: SizedBox(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              // CHARACTER IMAGE
-              ClipOvalCircleAvatar.create(
-                svgPath: item!.interviewer.iconPath,
-                size: 64,
-              ),
-              const SizedBox(
-                width: 16,
-              ),
-              SizedBox(
-                width: AppSize.ratioWidth(174),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // CHARACTER NAME
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16) +
+              const EdgeInsets.only(top: 24, bottom: 24),
+          child: SizedBox(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                // CHARACTER IMAGE
+                ClipOvalCircleAvatar.create(
+                  svgPath: item!.interviewer.iconPath,
+                  size: 64,
+                ),
+                const SizedBox(
+                  width: 16,
+                ),
+                SizedBox(
+                  width: AppSize.ratioWidth(174),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // CHARACTER NAME
+                      Text(
+                        tr(LocaleKeys.common_interviewTerms_interviewer, args: [
+                          tr(item!.interviewer.name),
+                        ]),
+                        style: AppTextStyle.title1,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
+                      ),
+                      const Gap(9),
+
+                      /// LAST CHAT MESSAGE or TOPIC CHIP LIST
+                      Builder(
+                        builder: (context) {
+                          if (item!.type.isPractical) {
+                            return Wrap(
+                              children: [
+                                ...List.generate(
+                                  item!.topics.length,
+                                  (index) => NormalRoundedChip(
+                                    margin: const EdgeInsets.only(
+                                      bottom: 6,
+                                      right: 6,
+                                    ),
+                                    text: item!.topics[index].text,
+                                  ),
+                                )
+                              ],
+                            );
+                          } else {
+                            return Text(
+                              item!.lastChatMessage ?? '',
+                              style: AppTextStyle.alert2,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            );
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+
+                const Spacer(),
+
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: <Widget>[
+                    // LAST CHAT DATE
                     Text(
-                      tr(LocaleKeys.common_interviewTerms_interviewer, args: [
-                        tr(item!.interviewer.name),
-                      ]),
-                      style: AppTextStyle.title1,
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
+                      item!.lastChatDate?.formatyyMMdd ?? '',
+                      style: AppTextStyle.alert2.copyWith(
+                        color: AppColor.of.gray3,
+                      ),
                     ),
                     const Gap(9),
-
-                    /// LAST CHAT MESSAGE or TOPIC CHIP LIST
+                    // PROGRESS INDICATOR
                     Builder(
                       builder: (context) {
-                        if (item!.type.isPractical) {
-                          return Wrap(
-                            children: [
-                              ...List.generate(
-                                item!.topics.length,
-                                (index) => NormalRoundedChip(
-                                  margin: const EdgeInsets.only(
-                                    bottom: 6,
-                                    right: 6,
-                                  ),
-                                  text: item!.topics[index].text,
-                                ),
-                              )
-                            ],
-                          );
-                        } else {
-                          return Text(
-                            item!.lastChatMessage ?? '',
-                            style: AppTextStyle.alert2,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          );
+                        switch (item!.progressState) {
+                          case ChatRoomProgress.initial ||
+                                ChatRoomProgress.ongoing:
+                            return NormalRoundedChip(
+                              text:
+                                  '${item!.completedQuestionCount}/${item!.progressInfo.totalQuestionCount}',
+                            );
+
+                          case ChatRoomProgress.completed:
+                            return ResponseIndicator(
+                              followupStatus: FollowupStatus
+                                  .no, // TODO : 꼬리질문 기능 도입시 해당 부분 수정 필요
+                              chatResult: item!.passOrFail,
+                              text: item!.passOrFail.isPassed
+                                  ? context
+                                      .tr(LocaleKeys.common_responseResult_pass)
+                                  : context.tr(
+                                      LocaleKeys.common_responseResult_fail,
+                                    ),
+                            );
+                          default:
+                            throw UnimplementedError('잘못된 enum값 입니다');
                         }
                       },
                     ),
                   ],
                 ),
-              ),
-
-              const Spacer(),
-
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: <Widget>[
-                  // LAST CHAT DATE
-                  Text(
-                    item!.lastChatDate?.formatyyMMdd ?? '',
-                    style: AppTextStyle.alert2.copyWith(
-                      color: AppColor.of.gray3,
-                    ),
-                  ),
-                  const Gap(9),
-                  // PROGRESS INDICATOR
-                  Builder(
-                    builder: (context) {
-                      switch (item!.progressState) {
-                        case ChatRoomProgress.initial ||
-                              ChatRoomProgress.ongoing:
-                          return NormalRoundedChip(
-                            text:
-                                '${item!.completedQuestionCount}/${item!.progressInfo.totalQuestionCount}',
-                          );
-
-                        case ChatRoomProgress.completed:
-                          return ResponseIndicator(
-                            followupStatus: FollowupStatus.no, // TODO : 꼬리질문 기능 도입시 해당 부분 수정 필요
-                            chatResult: item!.passOrFail,
-                            text: item!.passOrFail.isPassed
-                                ? context
-                                    .tr(LocaleKeys.common_responseResult_pass)
-                                : context.tr(
-                                    LocaleKeys.common_responseResult_fail,
-                                  ),
-                          );
-                        default:
-                          throw UnimplementedError('잘못된 enum값 입니다');
-                      }
-                    },
-                  ),
-                ],
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       );

--- a/lib/presentation/pages/interview/chat_list/providers/interview_rooms_provider.dart
+++ b/lib/presentation/pages/interview/chat_list/providers/interview_rooms_provider.dart
@@ -14,28 +14,44 @@ class InterviewRooms extends _$InterviewRooms {
   FutureOr<List<ChatRoomEntity>> build() async {
     final passedArg = ref.read(chatListRouteArgProvider);
 
-    final type = passedArg.interviewType;
-    final topic = passedArg.topic;
-    final passedChatRooms = passedArg.chatRooms;
+    return passedArg.interviewType.typedBranch(
+      common: (_) async {
+        final type = passedArg.interviewType;
+        final topic = passedArg.topic;
+        final passedChatRooms = passedArg.chatRooms;
 
-    if (passedArg.interviewType.isPractical) {
-      if (passedChatRooms != null && passedChatRooms.isNotEmpty) {
-        return passedChatRooms;
-      } else {
-        return ref.watch(practicalChatRoomListProvider.future);
-      }
-    } else {
-      final response = await getChatRoomsUseCase(
-          type, topic ?? ref.read(selectedChatRoomProvider).singleTopic);
+        if (passedArg.interviewType.isPractical) {
+          if (passedChatRooms != null && passedChatRooms.isNotEmpty) {
+            return passedChatRooms;
+          } else {
+            return ref.watch(practicalChatRoomListProvider.future);
+          }
+        } else {
+          final response = await getChatRoomsUseCase(
+              type, topic ?? ref.read(selectedChatRoomProvider).singleTopic);
 
-      return response.fold(
-        onSuccess: (chatList) => chatList,
-        onFailure: (e) {
-          log(e.toString());
-          throw e;
-        },
-      );
-    }
+          return response.fold(
+            onSuccess: (chatList) => chatList,
+            onFailure: (e) {
+              log(e.toString());
+              throw e;
+            },
+          );
+        }
+      },
+      resume: (_) async {
+        final response =
+            await getChatRoomsUseCase(passedArg.interviewType, null);
+
+        return response.fold(
+          onSuccess: (chatList) => chatList,
+          onFailure: (e) {
+            log(e.toString());
+            throw e;
+          },
+        );
+      },
+    );
   }
 
   void synchronizeRooms(ChatRoomEntity currentRoom) {

--- a/lib/presentation/pages/interview/chat_list/providers/interview_rooms_provider.g.dart
+++ b/lib/presentation/pages/interview/chat_list/providers/interview_rooms_provider.g.dart
@@ -6,7 +6,7 @@ part of 'interview_rooms_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$interviewRoomsHash() => r'39a28bc05f1a92ce82607b5d748da84d06b61655';
+String _$interviewRoomsHash() => r'9cfdb33f7c4ff29ed03575bbe59be12e0ab75fe2';
 
 /// See also [InterviewRooms].
 @ProviderFor(InterviewRooms)

--- a/lib/presentation/pages/interview/chat_list/providers/practical_chat_room_list_provider.dart
+++ b/lib/presentation/pages/interview/chat_list/providers/practical_chat_room_list_provider.dart
@@ -11,7 +11,8 @@ part 'practical_chat_room_list_provider.g.dart';
 class PracticalChatRoomList extends _$PracticalChatRoomList {
   @override
   FutureOr<List<ChatRoomEntity>> build() async {
-    final response = await getChatRoomsUseCase.call(InterviewType.practical);
+    final response =
+        await getChatRoomsUseCase.call(InterviewType.commonPracticalTopic);
     return response.fold(
       onSuccess: (chatRooms) => chatRooms,
       onFailure: (e) {

--- a/lib/presentation/pages/interview/chat_list/providers/practical_chat_room_list_provider.g.dart
+++ b/lib/presentation/pages/interview/chat_list/providers/practical_chat_room_list_provider.g.dart
@@ -7,7 +7,7 @@ part of 'practical_chat_room_list_provider.dart';
 // **************************************************************************
 
 String _$practicalChatRoomListHash() =>
-    r'773cc9d729ca5f1ccac1ed0a6d5b4d02a6f8cc5d';
+    r'64d5619647f0b3bf7e4cce96e9e492de37ea9e7a';
 
 /// See also [PracticalChatRoomList].
 @ProviderFor(PracticalChatRoomList)

--- a/lib/presentation/pages/interview/question_count_select/question_count_select_event.dart
+++ b/lib/presentation/pages/interview/question_count_select/question_count_select_event.dart
@@ -24,7 +24,7 @@ mixin class QuestionCountSelectEvent {
     final questionCount = ref.read(selectedQuestionCountProvider) +
         SelectedQuestionCount.defaultPlusCount;
 
-    final room = ChatRoomEntity.random(
+    final room = ChatRoomEntity.generateCommonInterview(
       type: type,
       topics: topics,
       questionCount: questionCount,

--- a/lib/presentation/pages/study/learning/providers/study_qnas_provider.g.dart
+++ b/lib/presentation/pages/study/learning/providers/study_qnas_provider.g.dart
@@ -6,7 +6,7 @@ part of 'study_qnas_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$studyQnasHash() => r'74c8ed4640bcbff51e51b30129be15986ceffe2b';
+String _$studyQnasHash() => r'cf18ae5315255a38ca17e0e7e4c8a0fc8e069959';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/presentation/pages/wrong_answer_note/local_widgets/wrong_answer_empty_list_placeholder.dart
+++ b/lib/presentation/pages/wrong_answer_note/local_widgets/wrong_answer_empty_list_placeholder.dart
@@ -53,7 +53,7 @@ class _EmptyListPlaceholder extends ConsumerWidget
                     onPressed: () {
                       routeToTopicSelection(
                         ref,
-                        type: InterviewType.singleTopic,
+                        type: InterviewType.commonSingleTopic,
                       );
                     },
                     child: Text(
@@ -75,7 +75,7 @@ class _EmptyListPlaceholder extends ConsumerWidget
                     onPressed: () {
                       routeToTopicSelection(
                         ref,
-                        type: InterviewType.practical,
+                        type: InterviewType.commonPracticalTopic,
                       );
                     },
                     child: Text(

--- a/lib/presentation/pages/wrong_answer_note/wrong_answer_note_event.dart
+++ b/lib/presentation/pages/wrong_answer_note/wrong_answer_note_event.dart
@@ -36,7 +36,7 @@ mixin class WrongAnswerNoteEvent {
   ///
   void routeToSingleSubjectQuestionCount(WidgetRef ref) {
     final selectedTopic = ref.read(selectedWrongAnswerTopicProvider);
-    const type = InterviewType.singleTopic;
+    const type = InterviewType.commonSingleTopic;
 
     final route = QuestionCountSelectPageRoute(type, selectedTopic!.id);
 

--- a/lib/presentation/widgets/common/chip/resume_question_type_chip.dart
+++ b/lib/presentation/widgets/common/chip/resume_question_type_chip.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:techtalk/app/style/app_color.dart';
+import 'package:techtalk/app/style/app_text_style.dart';
+import 'package:techtalk/features/chat/repositories/enums/resume_question_type.enum.dart';
+
+///
+/// 이력서 기발 면접 질문 > 소프트 or 하드 스킬 여부를 나타내는 chip
+///
+class ResumeQuestionTypeChip extends StatelessWidget {
+  const ResumeQuestionTypeChip({super.key, required this.type, this.margin});
+
+  final ResumeQuestionType type;
+  final EdgeInsets? margin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 30,
+      margin: margin,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      decoration: BoxDecoration(
+        color: AppColor.of.white,
+        border: Border.all(
+          color: AppColor.of.gray2,
+        ),
+        borderRadius: BorderRadius.circular(
+          8,
+        ),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        type.label,
+        style: AppTextStyle.body3.copyWith(
+          color: AppColor.of.gray4,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/common/indicator/new_badge.dart
+++ b/lib/presentation/widgets/common/indicator/new_badge.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:techtalk/app/style/app_text_style.dart';
+import 'package:techtalk/app/style/index.dart';
+
+class NewBadge extends StatelessWidget {
+  const NewBadge({super.key, this.margin});
+
+  final EdgeInsets? margin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 21,
+      margin: margin,
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: const Color(
+          0xFFFFF5BE,
+        ),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        'NEW',
+        style: AppTextStyle.alert1.copyWith(
+          fontWeight: FontWeight.w700,
+          color: const Color(0xFFFFA100),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/common/indicator/response_indicator.dart
+++ b/lib/presentation/widgets/common/indicator/response_indicator.dart
@@ -37,7 +37,8 @@ class ResponseIndicator extends StatelessWidget {
   /// 정답,오답 인디케이터
   Widget _buildPassFailIndicator() {
     return Container(
-      padding: const EdgeInsets.fromLTRB(8, 6, 6, 6),
+      height: 30,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
       decoration: BoxDecoration(
         color: chatResult.isPassed ? AppColor.of.blue1 : AppColor.of.red1,
         borderRadius: BorderRadius.circular(8),
@@ -46,9 +47,10 @@ class ResponseIndicator extends StatelessWidget {
         children: <Widget>[
           Text(
             text,
-            style: AppTextStyle.alert1.copyWith(
+            style: AppTextStyle.body3.copyWith(
               color:
                   chatResult.isPassed ? AppColor.of.brand3 : AppColor.of.red2,
+              fontWeight: FontWeight.w700,
             ),
           ),
           const SizedBox(
@@ -80,8 +82,9 @@ class ResponseIndicator extends StatelessWidget {
         children: <Widget>[
           Text(
             '꼬리질문', //TODO: Localization 적용해야함
-            style: AppTextStyle.alert1.copyWith(
+            style: AppTextStyle.body3.copyWith(
               color: AppColor.of.purple2,
+              fontWeight: FontWeight.w700,
             ),
           ),
           const SizedBox(


### PR DESCRIPTION
## 📝 변경 내용
- 기존 데이터베이스에 저장된 주제별 면접 질문뿐만 아니라, 이력서 기반 면접 질문도 동일한 AI 채팅 면접 프로세스를 진행할 수 있도록 여러 예외 처리 로직 추가
- QnaEntity 데이터 클래스 추상화 작업: BaseQnaEntity → ResumeQnaEntity, CommonQnaEntity로 분리
- 문답 탭: 이력서 면접 기록 관련 데이터 노출 UI 작업 및 공통 위젯으로 리팩토링
- 면접 유형별 useCases 및 provider 예외 처리 로직 추가
- 면접 유형별 데이터를 등록 및 저장하는 로직 분기 처리
- 이력서 면접 관련 Firestore Database Document Field 구조 설정
  - ![target_field](https://github.com/user-attachments/assets/3e96f8e8-4685-4d0a-9e0a-f96cb50128ce)

## 👥 리뷰어
@Yellowtoast , @yundal8755 

<br>

## 📌 기타 사항
- 걱정했던 것(?)보다 면접 유형별 예외 처리 로직의 복잡도가 높지 않았습니다. 이후 유튜브 영상 학습 면접의 경우에도 큰 문제가 없을 것 같습니다.
- 이력서 면접 질문 중 소프트 스킬 질문의 경우 정답 여부를 판단하지 않는다는 요구사항이 있었는데요. 오히려 해당 정책이 사용자에게 혼란을 줄 수 있을 것 같아서 일단 배제했습니다. 자세한 내용은 정리해서 슬랙에 공유드리겠습니다.

