### PR TITLE
[영상 학습] content overview 데이터 호출 및 매핑 구조 변경

### DIFF
--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/core/constants/stored_topic.dart';
 import 'package:techtalk/features/chat/chat.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
 import 'package:techtalk/presentation/pages/interview/chat/chat_page.dart';
@@ -239,7 +240,7 @@ class ContentsDetailRoute extends GoRouteData {
   static const String path = 'contents-detail/:contentsId';
   static const String name = 'contents-detail';
 
-  final ContentsOverviewEntity $extra;
+  final YoutubeContentOverviewEntity $extra;
 
   final String contentsId;
 
@@ -299,7 +300,8 @@ class QuestionCountSelectPageRoute extends GoRouteData {
   }
 
   /// NOTE: $extra 이슈로 직접 업데이트
-  void updateArg({required InterviewType type, required List<TopicEntity> topics}) {
+  void updateArg(
+      {required InterviewType type, required List<TopicEntity> topics}) {
     arg = (topics: topics, type: type);
   }
 }
@@ -351,7 +353,11 @@ class ChatListRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    arg = (topic: StoredTopics.getByIdOrNull(topicId), interviewType: type, chatRooms: $extra);
+    arg = (
+      topic: StoredTopics.getByIdOrNull(topicId),
+      interviewType: type,
+      chatRooms: $extra
+    );
     return ChatListPage();
   }
 }
@@ -376,7 +382,8 @@ class ChatPageRoute extends GoRouteData {
         var end = Offset.zero;
         var curve = Curves.ease;
 
-        var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+        var tween =
+            Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
 
         return SlideTransition(
           position: animation.drive(tween),

--- a/lib/app/router/router.g.dart
+++ b/lib/app/router/router.g.dart
@@ -311,7 +311,7 @@ extension $YoutubeContentsMainListRouteExtension
 extension $ContentsDetailRouteExtension on ContentsDetailRoute {
   static ContentsDetailRoute _fromState(GoRouterState state) =>
       ContentsDetailRoute(
-        state.extra as ContentsOverviewEntity,
+        state.extra as YoutubeContentOverviewEntity,
       );
 
   String get location => GoRouteData.$location(

--- a/lib/features/contents/data_source/remote/models/contents_author_model.dart
+++ b/lib/features/contents/data_source/remote/models/contents_author_model.dart
@@ -10,16 +10,11 @@ class ContentsAuthorModel {
     required this.id,
     required this.name,
     required this.profileImgUrl,
-    required this.homePageUrl,
   });
 
   final String id;
-
   final String name;
-
   final String? profileImgUrl;
-
-  final String? homePageUrl;
 
   /// 엔티티로 변환
 
@@ -28,7 +23,6 @@ class ContentsAuthorModel {
       id: id,
       name: name,
       profileImgUrl: profileImgUrl,
-      homePageUrl: homePageUrl,
     );
   }
 
@@ -40,7 +34,8 @@ class ContentsAuthorModel {
       ContentsAuthorModel.fromJson(snapshot.data()!);
 
   /// JSON에서 모델로 변환
-  factory ContentsAuthorModel.fromJson(Map<String, dynamic> json) => _$ContentsAuthorModelFromJson(json);
+  factory ContentsAuthorModel.fromJson(Map<String, dynamic> json) =>
+      _$ContentsAuthorModelFromJson(json);
 
   /// 모델을 JSON으로 변환
   Map<String, dynamic> toJson() => _$ContentsAuthorModelToJson(this);

--- a/lib/features/contents/data_source/remote/models/contents_author_model.dart
+++ b/lib/features/contents/data_source/remote/models/contents_author_model.dart
@@ -5,38 +5,38 @@ import 'package:techtalk/features/contents/repositories/entities/contents_author
 part 'contents_author_model.g.dart';
 
 @JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
-class ContentsAuthorModel {
-  ContentsAuthorModel({
+class ChannelModel {
+  ChannelModel({
     required this.id,
     required this.name,
-    required this.profileImgUrl,
+    required this.logoUrl,
   });
 
   final String id;
   final String name;
-  final String? profileImgUrl;
+  final String? logoUrl;
 
   /// 엔티티로 변환
 
-  ContentsAuthorEntity toEntity() {
-    return ContentsAuthorEntity(
+  ChannelEntity toEntity() {
+    return ChannelEntity(
       id: id,
       name: name,
-      profileImgUrl: profileImgUrl,
+      logoUrl: logoUrl,
     );
   }
 
   /// Firestore에서 가져온 DocumentSnapshot을 모델로 변환
-  factory ContentsAuthorModel.fromFirestore(
+  factory ChannelModel.fromFirestore(
     DocumentSnapshot<Map<String, dynamic>> snapshot,
     SnapshotOptions? options,
   ) =>
-      ContentsAuthorModel.fromJson(snapshot.data()!);
+      ChannelModel.fromJson(snapshot.data()!);
 
   /// JSON에서 모델로 변환
-  factory ContentsAuthorModel.fromJson(Map<String, dynamic> json) =>
-      _$ContentsAuthorModelFromJson(json);
+  factory ChannelModel.fromJson(Map<String, dynamic> json) =>
+      _$ChannelModelFromJson(json);
 
   /// 모델을 JSON으로 변환
-  Map<String, dynamic> toJson() => _$ContentsAuthorModelToJson(this);
+  Map<String, dynamic> toJson() => _$ChannelModelToJson(this);
 }

--- a/lib/features/contents/data_source/remote/models/contents_author_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/contents_author_model.g.dart
@@ -6,17 +6,15 @@ part of 'contents_author_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-ContentsAuthorModel _$ContentsAuthorModelFromJson(Map<String, dynamic> json) =>
-    ContentsAuthorModel(
+ChannelModel _$ChannelModelFromJson(Map<String, dynamic> json) => ChannelModel(
       id: json['id'] as String,
       name: json['name'] as String,
-      profileImgUrl: json['profile_img_url'] as String?,
+      logoUrl: json['logo_url'] as String?,
     );
 
-Map<String, dynamic> _$ContentsAuthorModelToJson(
-        ContentsAuthorModel instance) =>
+Map<String, dynamic> _$ChannelModelToJson(ChannelModel instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
-      'profile_img_url': instance.profileImgUrl,
+      'logo_url': instance.logoUrl,
     };

--- a/lib/features/contents/data_source/remote/models/contents_author_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/contents_author_model.g.dart
@@ -11,7 +11,6 @@ ContentsAuthorModel _$ContentsAuthorModelFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       name: json['name'] as String,
       profileImgUrl: json['profile_img_url'] as String?,
-      homePageUrl: json['home_page_url'] as String?,
     );
 
 Map<String, dynamic> _$ContentsAuthorModelToJson(
@@ -20,5 +19,4 @@ Map<String, dynamic> _$ContentsAuthorModelToJson(
       'id': instance.id,
       'name': instance.name,
       'profile_img_url': instance.profileImgUrl,
-      'home_page_url': instance.homePageUrl,
     };

--- a/lib/features/contents/data_source/remote/models/youtube_content_overview_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_content_overview_model.dart
@@ -1,0 +1,51 @@
+import 'package:techtalk/core/constants/job_group.enum.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
+import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
+
+class YoutubeContentOverviewEntity {
+  final String id;
+
+  final String thumbnailImgUrl;
+
+  final String contentsTitle;
+
+  final int qnaNum; // 아직 등록되지 않은 비디오면 0이 기본값
+
+  final ChannelEntity channel;
+
+  final Set<String> relatedSkillIds;
+
+  final Set<JobGroup> relatedJobs;
+
+  final DateTime uploadAt;
+
+  final DateTime createdAt;
+
+  final Duration videoDuration;
+
+  YoutubeContentOverviewEntity({
+    required this.id,
+    required this.thumbnailImgUrl,
+    required this.contentsTitle,
+    required this.channel,
+    required this.relatedJobs,
+    required this.relatedSkillIds,
+    required this.videoDuration,
+    required this.createdAt,
+    required this.uploadAt,
+    this.qnaNum = 0,
+  });
+
+  YoutubeContentsOverviewModel toModel() => YoutubeContentsOverviewModel(
+        id: id,
+        contentsTitle: contentsTitle,
+        thumbnailImgUrl: thumbnailImgUrl,
+        videoDuration: videoDuration,
+        qnaNum: qnaNum,
+        relatedSkillIds: relatedSkillIds.toList(),
+        relatedJobGroupIds: relatedJobs.map((job) => job.id).toList(),
+        channel: channel.toModel(),
+        uploadAt: uploadAt,
+        createdAt: createdAt,
+      );
+}

--- a/lib/features/contents/data_source/remote/models/youtube_content_overview_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_content_overview_model.dart
@@ -1,5 +1,7 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:techtalk/core/constants/job_group.enum.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/youtube_contents_overview_ref.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
 
 class YoutubeContentOverviewEntity {
@@ -47,5 +49,7 @@ class YoutubeContentOverviewEntity {
         channel: channel.toModel(),
         uploadAt: uploadAt,
         createdAt: createdAt,
+        channelRef:
+            FirestoreYoutubeContentsOverviewRef.channelDocumentRef(channel.id),
       );
 }

--- a/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart
@@ -3,6 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:techtalk/core/constants/job_group.enum.dart';
 import 'package:techtalk/core/modules/converter/time_stamp_converter.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/contents_author_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 
 part 'youtube_video_contents_overview_model.g.dart';
@@ -17,7 +18,7 @@ class YoutubeContentsOverviewModel {
     required this.qnaNum,
     required this.relatedSkillIds,
     required this.relatedJobGroupIds,
-    required this.author,
+    required this.channel,
     required this.uploadAt,
     required this.createdAt,
   });
@@ -36,7 +37,10 @@ class YoutubeContentsOverviewModel {
 
   final List<String> relatedJobGroupIds;
 
-  final ContentsAuthorModel author;
+  /// TODO : XIMYA
+  /// 추후 필드명 변경
+  @JsonKey(name: 'author')
+  final ChannelModel channel;
 
   @TimeStampConverter()
   final DateTime createdAt;
@@ -45,13 +49,13 @@ class YoutubeContentsOverviewModel {
   final DateTime uploadAt;
 
   /// 엔티티로 변환
-  YoutubeContentsOverviewEntity toEntity() {
-    return YoutubeContentsOverviewEntity(
+  YoutubeContentOverviewEntity toEntity() {
+    return YoutubeContentOverviewEntity(
       id: id,
       thumbnailImgUrl: thumbnailImgUrl,
       contentsTitle: contentsTitle,
       qnaNum: qnaNum,
-      author: author.toEntity(),
+      channel: channel.toEntity(),
       relatedSkillIds: relatedSkillIds.toSet(),
       relatedJobs: relatedJobGroupIds.map(JobGroup.getById).toSet(),
       videoDuration: videoDuration,

--- a/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart
@@ -4,6 +4,7 @@ import 'package:techtalk/core/constants/job_group.enum.dart';
 import 'package:techtalk/core/modules/converter/time_stamp_converter.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/contents_author_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
+import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 
 part 'youtube_video_contents_overview_model.g.dart';
@@ -16,9 +17,10 @@ class YoutubeContentsOverviewModel {
     required this.thumbnailImgUrl,
     required this.videoDuration,
     required this.qnaNum,
+    this.channelRef,
+    this.channel,
     required this.relatedSkillIds,
     required this.relatedJobGroupIds,
-    required this.channel,
     required this.uploadAt,
     required this.createdAt,
   });
@@ -37,16 +39,19 @@ class YoutubeContentsOverviewModel {
 
   final List<String> relatedJobGroupIds;
 
-  /// TODO : XIMYA
-  /// 추후 필드명 변경
-  @JsonKey(name: 'author')
-  final ChannelModel channel;
-
   @TimeStampConverter()
   final DateTime createdAt;
 
   @TimeStampConverter()
   final DateTime uploadAt;
+
+  /// Firestore의 DocumentReference 필드
+  @JsonKey(includeFromJson: false) // JSON 직렬화에서 무시
+  final DocumentReference? channelRef;
+
+  /// 채널정보
+  /// [channelRef]를 통해 참조된 데이터로 필드가 갱신됨
+  final ChannelModel? channel;
 
   /// 엔티티로 변환
   YoutubeContentOverviewEntity toEntity() {
@@ -55,7 +60,7 @@ class YoutubeContentsOverviewModel {
       thumbnailImgUrl: thumbnailImgUrl,
       contentsTitle: contentsTitle,
       qnaNum: qnaNum,
-      channel: channel.toEntity(),
+      channel: channel?.toEntity() ?? ChannelEntity.undefined(),
       relatedSkillIds: relatedSkillIds.toSet(),
       relatedJobs: relatedJobGroupIds.map(JobGroup.getById).toSet(),
       videoDuration: videoDuration,
@@ -68,8 +73,12 @@ class YoutubeContentsOverviewModel {
   factory YoutubeContentsOverviewModel.fromFirestore(
     DocumentSnapshot<Map<String, dynamic>> snapshot,
     SnapshotOptions? options,
-  ) =>
-      YoutubeContentsOverviewModel.fromJson(snapshot.data()!);
+  ) {
+    final channelRef =
+        snapshot.data()!['channel_ref'] as DocumentReference?; // 수동으로 처리
+    return YoutubeContentsOverviewModel.fromJson(snapshot.data()!)
+        .copyWith(channelRef: channelRef);
+  }
 
   /// JSON에서 모델로 변환
   factory YoutubeContentsOverviewModel.fromJson(Map<String, dynamic> json) =>
@@ -77,4 +86,32 @@ class YoutubeContentsOverviewModel {
 
   /// 모델을 JSON으로 변환
   Map<String, dynamic> toJson() => _$YoutubeContentsOverviewModelToJson(this);
+
+  YoutubeContentsOverviewModel copyWith({
+    String? id,
+    String? thumbnailImgUrl,
+    String? contentsTitle,
+    Duration? videoDuration,
+    int? qnaNum,
+    List<String>? relatedSkillIds,
+    List<String>? relatedJobGroupIds,
+    ChannelModel? channel,
+    DateTime? createdAt,
+    DateTime? uploadAt,
+    DocumentReference? channelRef,
+  }) {
+    return YoutubeContentsOverviewModel(
+      id: id ?? this.id,
+      thumbnailImgUrl: thumbnailImgUrl ?? this.thumbnailImgUrl,
+      contentsTitle: contentsTitle ?? this.contentsTitle,
+      videoDuration: videoDuration ?? this.videoDuration,
+      qnaNum: qnaNum ?? this.qnaNum,
+      relatedSkillIds: relatedSkillIds ?? this.relatedSkillIds,
+      relatedJobGroupIds: relatedJobGroupIds ?? this.relatedJobGroupIds,
+      channel: channel ?? this.channel,
+      createdAt: createdAt ?? this.createdAt,
+      uploadAt: uploadAt ?? this.uploadAt,
+      channelRef: channelRef ?? this.channelRef,
+    );
+  }
 }

--- a/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.g.dart
@@ -15,13 +15,15 @@ YoutubeContentsOverviewModel _$YoutubeContentsOverviewModelFromJson(
       videoDuration:
           Duration(microseconds: (json['video_duration'] as num).toInt()),
       qnaNum: (json['qna_num'] as num).toInt(),
+      channel: json['channel'] == null
+          ? null
+          : ChannelModel.fromJson(json['channel'] as Map<String, dynamic>),
       relatedSkillIds: (json['related_skill_ids'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
       relatedJobGroupIds: (json['related_job_group_ids'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
-      channel: ChannelModel.fromJson(json['author'] as Map<String, dynamic>),
       uploadAt:
           const TimeStampConverter().fromJson(json['upload_at'] as Timestamp),
       createdAt:
@@ -38,7 +40,7 @@ Map<String, dynamic> _$YoutubeContentsOverviewModelToJson(
       'qna_num': instance.qnaNum,
       'related_skill_ids': instance.relatedSkillIds,
       'related_job_group_ids': instance.relatedJobGroupIds,
-      'author': instance.channel.toJson(),
       'created_at': const TimeStampConverter().toJson(instance.createdAt),
       'upload_at': const TimeStampConverter().toJson(instance.uploadAt),
+      'channel': instance.channel?.toJson(),
     };

--- a/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.g.dart
@@ -21,8 +21,7 @@ YoutubeContentsOverviewModel _$YoutubeContentsOverviewModelFromJson(
       relatedJobGroupIds: (json['related_job_group_ids'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
-      author:
-          ContentsAuthorModel.fromJson(json['author'] as Map<String, dynamic>),
+      channel: ChannelModel.fromJson(json['author'] as Map<String, dynamic>),
       uploadAt:
           const TimeStampConverter().fromJson(json['upload_at'] as Timestamp),
       createdAt:
@@ -39,7 +38,7 @@ Map<String, dynamic> _$YoutubeContentsOverviewModelToJson(
       'qna_num': instance.qnaNum,
       'related_skill_ids': instance.relatedSkillIds,
       'related_job_group_ids': instance.relatedJobGroupIds,
-      'author': instance.author.toJson(),
+      'author': instance.channel.toJson(),
       'created_at': const TimeStampConverter().toJson(instance.createdAt),
       'upload_at': const TimeStampConverter().toJson(instance.uploadAt),
     };

--- a/lib/features/contents/data_source/remote/youtube_contents_overview_ref.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_overview_ref.dart
@@ -11,15 +11,23 @@ abstract class FirestoreYoutubeContentsOverviewRef {
           );
 
   static DocumentReference<YoutubeContentsOverviewModel> doc(String id) =>
-      FirebaseFirestore.instance.collection(_collectionName).doc(id).withConverter(
+      FirebaseFirestore.instance
+          .collection(_collectionName)
+          .doc(id)
+          .withConverter(
             fromFirestore: YoutubeContentsOverviewModel.fromFirestore,
             toFirestore: (value, options) => value.toJson(),
           );
+
+  static DocumentReference channelDocumentRef(String channelId) =>
+      FirebaseFirestore.instance.collection('Channel').doc(channelId);
 }
 
 @override
-Future<void> addYoutubeContentsOverview(String contentsId, YoutubeContentsOverviewModel overviewModel) async {
-  final ref = FirebaseFirestore.instance.collection('YoutubeOverview').doc(contentsId);
+Future<void> addYoutubeContentsOverview(
+    String contentsId, YoutubeContentsOverviewModel overviewModel) async {
+  final ref =
+      FirebaseFirestore.instance.collection('YoutubeOverview').doc(contentsId);
 
   await ref.set(overviewModel.toJson());
 }

--- a/lib/features/contents/data_source/remote/youtube_contents_remote_data_source_impl.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_remote_data_source_impl.dart
@@ -3,6 +3,7 @@ import 'package:techtalk/core/firebase_pagination_result.dart';
 import 'package:techtalk/core/firebase_query_constraints.dart';
 import 'package:techtalk/core/index.dart';
 import 'package:techtalk/core/query_constraints_applier.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/contents_author_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_contents_detail_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_detail_ref.dart';
@@ -10,13 +11,15 @@ import 'package:techtalk/features/contents/data_source/remote/youtube_contents_o
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_remote_data_source.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
-final class YoutubeContentsRemoteDataSourceImpl implements YoutubeContentsRemoteDataSource {
+final class YoutubeContentsRemoteDataSourceImpl
+    implements YoutubeContentsRemoteDataSource {
   final QueryConstraintApplier _constraintApplier;
 
   YoutubeContentsRemoteDataSourceImpl(this._constraintApplier);
 
   @override
-  Future<YoutubeContentsDetailModel> getYoutubeContentsDetail(String contentsId) async {
+  Future<YoutubeContentsDetailModel> getYoutubeContentsDetail(
+      String contentsId) async {
     final detailDoc = await FirestoreYoutubeDetailRef.doc(contentsId).get();
 
     if (!detailDoc.exists) {
@@ -27,15 +30,18 @@ final class YoutubeContentsRemoteDataSourceImpl implements YoutubeContentsRemote
   }
 
   @override
-  Future<List<TopicQnaModel>> getYoutubeContentsDetailQnas(String contentsId) async {
-    final collection = await FirestoreYoutubeDetailQuestionRef.collection(contentsId).get();
+  Future<List<TopicQnaModel>> getYoutubeContentsDetailQnas(
+      String contentsId) async {
+    final collection =
+        await FirestoreYoutubeDetailQuestionRef.collection(contentsId).get();
 
     return collection.docs.map((doc) => doc.data()).toList();
   }
 
   @override
-  Future<FirebasePaginatedResult<YoutubeContentsOverviewModel, YoutubeContentsOverviewModel>>
-      getYoutubeContentsOverviews({
+  Future<
+      FirebasePaginatedResult<YoutubeContentsOverviewModel,
+          YoutubeContentsOverviewModel>> getYoutubeContentsOverviews({
     required int limit,
     required String orderByField,
     DocumentSnapshot<YoutubeContentsOverviewModel>? lastDocument,
@@ -43,7 +49,9 @@ final class YoutubeContentsRemoteDataSourceImpl implements YoutubeContentsRemote
   }) async {
     try {
       Query<YoutubeContentsOverviewModel> query =
-          FirestoreYoutubeContentsOverviewRef.collection().orderBy(orderByField).limit(limit);
+          FirestoreYoutubeContentsOverviewRef.collection()
+              .orderBy(orderByField)
+              .limit(limit);
 
       if (lastDocument != null) {
         query = query.startAfterDocument(lastDocument);
@@ -56,15 +64,26 @@ final class YoutubeContentsRemoteDataSourceImpl implements YoutubeContentsRemote
 
       QuerySnapshot<YoutubeContentsOverviewModel> snapshot = await query.get();
 
-      final items = snapshot.docs.map((doc) => doc.data()).toList();
+      final items = await Future.wait(snapshot.docs.map((doc) async {
+        final targetData = doc.data();
+        // channel_ref를 통해 [ChannelModel] 데이터를 가져옴
+        final channelSnapshot = await targetData.channelRef?.get()
+            as DocumentSnapshot<Map<String, dynamic>>; // 타입 캐스팅
+        final channelModel = ChannelModel.fromFirestore(channelSnapshot, null);
+
+        return targetData.copyWith(channel: channelModel);
+      }).toList());
+
       final hasMore = snapshot.docs.length == limit;
-      final newLastDocument = snapshot.docs.isNotEmpty ? snapshot.docs.last : lastDocument;
+      final newLastDocument =
+          snapshot.docs.isNotEmpty ? snapshot.docs.last : lastDocument;
 
       if (newLastDocument == null && items.isNotEmpty) {
         throw Exception('Last document is null after fetching data.');
       }
 
-      return FirebasePaginatedResult<YoutubeContentsOverviewModel, YoutubeContentsOverviewModel>(
+      return FirebasePaginatedResult<YoutubeContentsOverviewModel,
+          YoutubeContentsOverviewModel>(
         items: items,
         lastDocument: newLastDocument!,
         hasMore: hasMore,

--- a/lib/features/contents/repositories/entities/contents_author_entity.dart
+++ b/lib/features/contents/repositories/entities/contents_author_entity.dart
@@ -11,20 +11,15 @@ class ContentsAuthorEntity {
   /// 저자의 프로필 이미지 url
   final String? profileImgUrl;
 
-  /// 저자의 메인 홈페이지 url
-  final String? homePageUrl;
-
   ContentsAuthorEntity({
     required this.id,
     required this.name,
     this.profileImgUrl,
-    this.homePageUrl,
   });
 
   ContentsAuthorModel toModel() => ContentsAuthorModel(
         id: id,
         name: name,
         profileImgUrl: profileImgUrl,
-        homePageUrl: homePageUrl,
       );
 }

--- a/lib/features/contents/repositories/entities/contents_author_entity.dart
+++ b/lib/features/contents/repositories/entities/contents_author_entity.dart
@@ -22,6 +22,12 @@ class ChannelEntity {
     this.logoUrl,
   });
 
+  ///
+  /// 호출에 실패했을 경우
+  ///
+  factory ChannelEntity.undefined() =>
+      ChannelEntity(id: 'undefined', name: '알 수 없는 채널');
+
   ChannelModel toModel() => ChannelModel(
         id: id,
         name: name,

--- a/lib/features/contents/repositories/entities/contents_author_entity.dart
+++ b/lib/features/contents/repositories/entities/contents_author_entity.dart
@@ -1,25 +1,30 @@
 import 'package:techtalk/features/contents/data_source/remote/models/contents_author_model.dart';
 
-/// 컨텐츠 저자 정보 인터페이스
-class ContentsAuthorEntity {
-  /// 저자 id
+///
+/// 유튜브 채널 정보
+///
+class ChannelEntity {
+  /// 채널 id
   final String id;
 
-  /// 저자 이름/닉네임
+  /// 채널명
   final String name;
 
-  /// 저자의 프로필 이미지 url
-  final String? profileImgUrl;
+  /// 채널의 로고 이미지
+  final String? logoUrl;
 
-  ContentsAuthorEntity({
+  /// 채널 url
+  String get url => 'https://www.youtube.com/channel/$id';
+
+  ChannelEntity({
     required this.id,
     required this.name,
-    this.profileImgUrl,
+    this.logoUrl,
   });
 
-  ContentsAuthorModel toModel() => ContentsAuthorModel(
+  ChannelModel toModel() => ChannelModel(
         id: id,
         name: name,
-        profileImgUrl: profileImgUrl,
+        logoUrl: logoUrl,
       );
 }

--- a/lib/features/contents/repositories/entities/contents_overview_entity.dart
+++ b/lib/features/contents/repositories/entities/contents_overview_entity.dart
@@ -8,6 +8,8 @@ import 'package:techtalk/features/contents/repositories/entities/contents_author
 /// 오버뷰는 리스트 형식으로 노출하기 떄문에, 다양한 타입의 클래스를 다룰 여지가 있다고 판단하여
 /// sealed class 로 선언
 ///
+
+@Deprecated('추후에 인터페이스가 필요할 떄 적용')
 sealed class ContentsOverviewEntity {
   /// 아이디
   final String id;
@@ -24,7 +26,7 @@ sealed class ContentsOverviewEntity {
   final int qnaNum;
 
   /// 컨텐츠 저자 정보
-  final ContentsAuthorEntity author;
+  final ChannelEntity author;
 
   /// 관련 기술 스킬 id
   final Set<String> relatedSkillIds;
@@ -47,63 +49,4 @@ sealed class ContentsOverviewEntity {
     required this.uploadAt,
     this.qnaNum = 0,
   });
-}
-
-class YoutubeContentsOverviewEntity implements ContentsOverviewEntity {
-  @override
-  final String id;
-
-  @override
-  @override
-  final String thumbnailImgUrl;
-
-  @override
-  final String contentsTitle;
-
-  @override
-  final int qnaNum; // 아직 등록되지 않은 비디오면 0이 기본값
-
-  @override
-  final ContentsAuthorEntity author;
-
-  @override
-  final Set<String> relatedSkillIds;
-
-  /// 관련 직군
-  @override
-  final Set<JobGroup> relatedJobs;
-
-  @override
-  final DateTime uploadAt;
-
-  @override
-  final DateTime createdAt;
-
-  final Duration videoDuration;
-
-  YoutubeContentsOverviewEntity({
-    required this.id,
-    required this.thumbnailImgUrl,
-    required this.contentsTitle,
-    required this.author,
-    required this.relatedJobs,
-    required this.relatedSkillIds,
-    required this.videoDuration,
-    required this.createdAt,
-    required this.uploadAt,
-    this.qnaNum = 0,
-  });
-
-  YoutubeContentsOverviewModel toModel() => YoutubeContentsOverviewModel(
-        id: id,
-        contentsTitle: contentsTitle,
-        thumbnailImgUrl: thumbnailImgUrl,
-        videoDuration: videoDuration,
-        qnaNum: qnaNum,
-        relatedSkillIds: relatedSkillIds.toList(),
-        relatedJobGroupIds: relatedJobs.map((job) => job.id).toList(),
-        author: author.toModel(),
-        uploadAt: uploadAt,
-        createdAt: createdAt,
-      );
 }

--- a/lib/features/contents/repositories/youtube_contents_repository.dart
+++ b/lib/features/contents/repositories/youtube_contents_repository.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:techtalk/core/firebase_pagination_result.dart';
 import 'package:techtalk/core/firebase_query_constraints.dart';
 import 'package:techtalk/core/modules/error_handling/result.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_contents_detail_entity.dart';
@@ -39,8 +40,10 @@ abstract interface class YoutubeContentsRepository {
   /// [limit] - 한 페이지당 가져올 항목 수
   /// [queryConstraints] - 추가적인 Firestore 쿼리 제약 조건
   ///
-  Future<Result<FirebasePaginatedResult<YoutubeContentsOverviewEntity, YoutubeContentsOverviewModel>>>
-      getYoutubeContentsOverviews({
+  Future<
+      Result<
+          FirebasePaginatedResult<YoutubeContentOverviewEntity,
+              YoutubeContentsOverviewModel>>> getYoutubeContentsOverviews({
     required int limit,
     required String orderByField,
     DocumentSnapshot<YoutubeContentsOverviewModel>? lastDocument,

--- a/lib/features/contents/repositories/youtube_contents_repository_impl.dart
+++ b/lib/features/contents/repositories/youtube_contents_repository_impl.dart
@@ -7,6 +7,7 @@ import 'package:techtalk/core/firebase_pagination_result.dart';
 import 'package:techtalk/core/firebase_query_constraints.dart';
 import 'package:techtalk/core/modules/error_handling/result.dart';
 import 'package:techtalk/core/modules/exceptions/custom_exception.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_remote_data_source.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
@@ -17,13 +18,15 @@ import 'package:techtalk/features/topic/topic.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
 class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
-  YoutubeContentsRepositoryImpl(this._youtubeApiDataSource, this._youtubeRemoteDataSource);
+  YoutubeContentsRepositoryImpl(
+      this._youtubeApiDataSource, this._youtubeRemoteDataSource);
 
   final YoutubeExplode _youtubeApiDataSource;
   final YoutubeContentsRemoteDataSource _youtubeRemoteDataSource;
 
   @override
-  Future<Result<YouTubeVideoDataEntity>> getYoutubeVideoData(String videoId) async {
+  Future<Result<YouTubeVideoDataEntity>> getYoutubeVideoData(
+      String videoId) async {
     try {
       final video = await _youtubeApiDataSource.videos.get(videoId);
       final channel = await _youtubeApiDataSource.channels.get(video.channelId);
@@ -47,9 +50,11 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
   }
 
   @override
-  Future<Result<YoutubeContentsDetailEntity>> getYoutubeContentsDetail(String videoId) async {
+  Future<Result<YoutubeContentsDetailEntity>> getYoutubeContentsDetail(
+      String videoId) async {
     try {
-      final remoteResponse = await _youtubeRemoteDataSource.getYoutubeContentsDetail(videoId);
+      final remoteResponse =
+          await _youtubeRemoteDataSource.getYoutubeContentsDetail(videoId);
 
       return Result.success(remoteResponse.toEntity());
     } on Exception catch (e) {
@@ -61,11 +66,14 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
   }
 
   @override
-  Future<Result<List<QnaEntity>>> getYoutubeContentsDetailQnas(String videoId) async {
+  Future<Result<List<QnaEntity>>> getYoutubeContentsDetailQnas(
+      String videoId) async {
     try {
-      final remoteResponse = await _youtubeRemoteDataSource.getYoutubeContentsDetailQnas(videoId);
+      final remoteResponse =
+          await _youtubeRemoteDataSource.getYoutubeContentsDetailQnas(videoId);
 
-      return Result.success(remoteResponse.map((data) => data.toEntity()).toList());
+      return Result.success(
+          remoteResponse.map((data) => data.toEntity()).toList());
     } on Exception catch (e) {
       log('getYoutubeContentsDetailQnas : $e');
       return Result.failure(
@@ -75,8 +83,10 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
   }
 
   @override
-  Future<Result<FirebasePaginatedResult<YoutubeContentsOverviewEntity, YoutubeContentsOverviewModel>>>
-      getYoutubeContentsOverviews({
+  Future<
+      Result<
+          FirebasePaginatedResult<YoutubeContentOverviewEntity,
+              YoutubeContentsOverviewModel>>> getYoutubeContentsOverviews({
     required int limit,
     required String orderByField,
     DocumentSnapshot<YoutubeContentsOverviewModel>? lastDocument,
@@ -84,7 +94,8 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
   }) async {
     try {
       // Remote DataSource에서 페이징된 데이터 가져오기
-      final remotePaginatedResult = await _youtubeRemoteDataSource.getYoutubeContentsOverviews(
+      final remotePaginatedResult =
+          await _youtubeRemoteDataSource.getYoutubeContentsOverviews(
         limit: limit,
         orderByField: orderByField,
         lastDocument: lastDocument,
@@ -92,10 +103,12 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
       );
 
       // 모델을 엔티티로 변환
-      final entities = remotePaginatedResult.items.map((model) => model.toEntity()).toList();
+      final entities =
+          remotePaginatedResult.items.map((model) => model.toEntity()).toList();
 
       // 엔티티로 페이징된 결과 생성
-      final paginatedResult = FirebasePaginatedResult<YoutubeContentsOverviewEntity, YoutubeContentsOverviewModel>(
+      final paginatedResult = FirebasePaginatedResult<
+          YoutubeContentOverviewEntity, YoutubeContentsOverviewModel>(
         items: entities,
         lastDocument: remotePaginatedResult.lastDocument,
         hasMore: remotePaginatedResult.hasMore,

--- a/lib/features/contents/usecases/get_youtube_overview_list_use_case.dart
+++ b/lib/features/contents/usecases/get_youtube_overview_list_use_case.dart
@@ -4,8 +4,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:techtalk/core/firebase_pagination_result.dart';
 import 'package:techtalk/core/firebase_query_constraints.dart';
 import 'package:techtalk/core/index.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
-import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 import 'package:techtalk/features/contents/repositories/youtube_contents_repository.dart';
 
 ///
@@ -28,14 +28,20 @@ final class GetYoutubeContentsOverviewsListParams {
 ///
 /// 유튜브 컨텐츠 리스트 페이이네이션
 ///
-final class GetYoutubeOverviewListUseCase extends BaseUseCase<GetYoutubeContentsOverviewsListParams,
-    Result<FirebasePaginatedResult<YoutubeContentsOverviewEntity, YoutubeContentsOverviewModel>>> {
+final class GetYoutubeOverviewListUseCase extends BaseUseCase<
+    GetYoutubeContentsOverviewsListParams,
+    Result<
+        FirebasePaginatedResult<YoutubeContentOverviewEntity,
+            YoutubeContentsOverviewModel>>> {
   GetYoutubeOverviewListUseCase(this._repository);
 
   final YoutubeContentsRepository _repository;
 
   @override
-  Future<Result<FirebasePaginatedResult<YoutubeContentsOverviewEntity, YoutubeContentsOverviewModel>>> call(
+  Future<
+      Result<
+          FirebasePaginatedResult<YoutubeContentOverviewEntity,
+              YoutubeContentsOverviewModel>>> call(
     GetYoutubeContentsOverviewsListParams request,
   ) =>
       _repository.getYoutubeContentsOverviews(

--- a/lib/features/topic/data_source/remote/models/topic_model.g.dart
+++ b/lib/features/topic/data_source/remote/models/topic_model.g.dart
@@ -31,6 +31,6 @@ Map<String, dynamic> _$TopicModelToJson(TopicModel instance) =>
       'en_name': instance.enName,
       'image_path': instance.imagePath,
       'is_available': instance.isAvailable,
-      'related_topics': instance.relatedSkillIds,
+      'related_skill_ids': instance.relatedSkillIds,
       'updated_at': const TimeStampConverter().toJson(instance.updatedAt),
     };

--- a/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.g.dart
+++ b/lib/presentation/pages/interview/chat/providers/interview_progress_state_provider.g.dart
@@ -7,7 +7,7 @@ part of 'interview_progress_state_provider.dart';
 // **************************************************************************
 
 String _$interviewProgressStateHash() =>
-    r'54364773b771ae58710800e4202476a8532c01ee';
+    r'a1550bd53d9e7c22afcfeb39e7a840892b0d59af';
 
 /// See also [InterviewProgressState].
 @ProviderFor(InterviewProgressState)

--- a/lib/presentation/pages/youtube/youtube_contents_detail_event.dart
+++ b/lib/presentation/pages/youtube/youtube_contents_detail_event.dart
@@ -5,7 +5,7 @@ import 'package:techtalk/presentation/pages/youtube/constants/contents_detail_ta
 mixin class YoutubeContentsDetailEvent {
   tabChanged(ContentsDetailTabType tabType) {}
 
-  onTapAuthorProfile(ContentsAuthorEntity author) {}
+  onTapAuthorProfile(ChannelEntity author) {}
 
   onTapUploaderProfile(UserEntity uploader) {}
 }

--- a/lib/presentation/pages/youtube/youtube_contents_detail_page.dart
+++ b/lib/presentation/pages/youtube/youtube_contents_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/app/style/app_color.dart';
 import 'package:techtalk/app/style/app_text_style.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 import 'package:techtalk/presentation/pages/youtube/constants/contents_detail_tab_type.enum.dart';
 import 'package:techtalk/presentation/pages/youtube/widgets/summary_note_foldable_item.dart';
@@ -13,10 +14,11 @@ import 'package:techtalk/presentation/widgets/common/box/async_skeleton_widget_b
 import 'package:techtalk/presentation/widgets/common/common.dart';
 
 /// 유튜브 컨텐츠 상세 페이지
-class YoutubeContentsDetailPage extends BasePage with YoutubeContentsDetailEvent, YoutubeContentsDetailState {
+class YoutubeContentsDetailPage extends BasePage
+    with YoutubeContentsDetailEvent, YoutubeContentsDetailState {
   const YoutubeContentsDetailPage({super.key, required this.overview});
 
-  final ContentsOverviewEntity overview;
+  final YoutubeContentOverviewEntity overview;
 
   @override
   Widget buildPage(BuildContext context, WidgetRef ref) {
@@ -61,7 +63,8 @@ class YoutubeContentsDetailPage extends BasePage with YoutubeContentsDetailEvent
             // 콘텐츠 영역을 SliverToBoxAdapter로 감싸기
             SliverToBoxAdapter(
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 20),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 15, vertical: 20),
                 child: Wrap(
                   runSpacing: 5,
                   children: [
@@ -107,12 +110,13 @@ class YoutubeContentsDetailPage extends BasePage with YoutubeContentsDetailEvent
                       skeletonBuilder: (_) => Row(
                         children: [
                           CircleAvatar(
-                            backgroundImage: NetworkImage(overview.author.profileImgUrl ?? ''),
+                            backgroundImage:
+                                NetworkImage(overview.channel.logoUrl ?? ''),
                             radius: 15,
                           ),
                           const SizedBox(width: 8),
                           Text(
-                            overview.author.name,
+                            overview.channel.name,
                           ),
                           const SizedBox(width: 8),
                         ],
@@ -120,7 +124,8 @@ class YoutubeContentsDetailPage extends BasePage with YoutubeContentsDetailEvent
                       dataBuilder: (context, data) => Row(
                         children: [
                           CircleAvatar(
-                            backgroundImage: NetworkImage(data.channelInfo.logoUrl),
+                            backgroundImage:
+                                NetworkImage(data.channelInfo.logoUrl),
                             radius: 15,
                           ),
                           const SizedBox(width: 8),
@@ -151,8 +156,10 @@ class YoutubeContentsDetailPage extends BasePage with YoutubeContentsDetailEvent
                   labelColor: Colors.black,
                   unselectedLabelColor: Colors.grey,
                   indicator: const UnderlineTabIndicator(
-                    borderSide: BorderSide(width: 2.0, color: Colors.black), // 인디케이터 두께와 색상
-                    insets: EdgeInsets.symmetric(horizontal: 70.0), // 인디케이터의 가로 여백 조정
+                    borderSide: BorderSide(
+                        width: 2.0, color: Colors.black), // 인디케이터 두께와 색상
+                    insets: EdgeInsets.symmetric(
+                        horizontal: 70.0), // 인디케이터의 가로 여백 조정
                   ),
                   tabs: ContentsDetailTabType.values
                       .map((tab) => Tab(
@@ -231,7 +238,8 @@ class YoutubeContentsDetailPage extends BasePage with YoutubeContentsDetailEvent
                 padding: const EdgeInsets.all(16),
                 children: [
                   AsyncSkeletonWidgetBuilder(
-                    asyncValue: youtubeContentsDetailQnasAsync(ref, overview.id),
+                    asyncValue:
+                        youtubeContentsDetailQnasAsync(ref, overview.id),
                     skeletonBuilder: (p0) => const Center(
                       child: CircularProgressIndicator(),
                     ),
@@ -288,7 +296,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   double get maxExtent => _tabBar.preferredSize.height;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
     return Container(
       color: AppColor.of.white,
       child: _tabBar,

--- a/lib/presentation/pages/youtube/youtube_contents_main_event.dart
+++ b/lib/presentation/pages/youtube/youtube_contents_main_event.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:techtalk/app/router/router.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 
 mixin class YoutubeContentsMainListEvent {
   void routeToDetailPage(
     BuildContext context, {
-    required ContentsOverviewEntity overview,
+    required YoutubeContentOverviewEntity overview,
   }) {
     final route = ContentsDetailRoute(overview);
     route.push(context);

--- a/lib/presentation/pages/youtube/youtube_contents_main_list_page.dart
+++ b/lib/presentation/pages/youtube/youtube_contents_main_list_page.dart
@@ -2,22 +2,25 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
 import 'package:techtalk/presentation/pages/youtube/youtube_contents_main_event.dart';
 import 'package:techtalk/presentation/pages/youtube/youtube_contents_overviews_provider.dart';
 import 'package:techtalk/presentation/widgets/base/base_page.dart';
 
-class YoutubeContentsMainListPage extends BasePage with YoutubeContentsMainListEvent {
+class YoutubeContentsMainListPage extends BasePage
+    with YoutubeContentsMainListEvent {
   const YoutubeContentsMainListPage({super.key});
 
   @override
   Widget buildPage(BuildContext context, WidgetRef ref) {
     final pagingController = ref.watch(youtubeContentsOverviewsProvider);
 
-    return PagedListView<DocumentSnapshot<YoutubeContentsOverviewModel>?, YoutubeContentsOverviewEntity>(
+    return PagedListView<DocumentSnapshot<YoutubeContentsOverviewModel>?,
+        YoutubeContentOverviewEntity>(
       pagingController: pagingController,
-      builderDelegate: PagedChildBuilderDelegate<YoutubeContentsOverviewEntity>(
+      builderDelegate: PagedChildBuilderDelegate<YoutubeContentOverviewEntity>(
         itemBuilder: (context, item, index) => ListTile(
           leading: Image.network(
             item.thumbnailImgUrl,
@@ -26,7 +29,7 @@ class YoutubeContentsMainListPage extends BasePage with YoutubeContentsMainListE
             fit: BoxFit.cover,
           ),
           title: Text(item.contentsTitle),
-          subtitle: Text('Author: ${item.author.name}'),
+          subtitle: Text('Author: ${item.channel.name}'),
           trailing: Text(
             '${item.videoDuration.inMinutes}m ${item.videoDuration.inSeconds % 60}s',
           ),
@@ -34,8 +37,10 @@ class YoutubeContentsMainListPage extends BasePage with YoutubeContentsMainListE
             routeToDetailPage(context, overview: item);
           },
         ),
-        firstPageProgressIndicatorBuilder: (context) => Center(child: CircularProgressIndicator()),
-        newPageProgressIndicatorBuilder: (context) => Center(child: CircularProgressIndicator()),
+        firstPageProgressIndicatorBuilder: (context) =>
+            Center(child: CircularProgressIndicator()),
+        newPageProgressIndicatorBuilder: (context) =>
+            Center(child: CircularProgressIndicator()),
         firstPageErrorIndicatorBuilder: (context) => Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -62,13 +67,15 @@ class YoutubeContentsMainListPage extends BasePage with YoutubeContentsMainListE
             ],
           ),
         ),
-        noItemsFoundIndicatorBuilder: (context) => Center(child: Text('데이터가 없습니다.')),
+        noItemsFoundIndicatorBuilder: (context) =>
+            Center(child: Text('데이터가 없습니다.')),
       ),
     );
   }
 
   @override
-  PreferredSizeWidget? buildAppBar(BuildContext context, WidgetRef ref) => AppBar(
+  PreferredSizeWidget? buildAppBar(BuildContext context, WidgetRef ref) =>
+      AppBar(
         title: Text('유튜브 컨텐츠 리스트'),
       );
 }

--- a/lib/presentation/pages/youtube/youtube_contents_overviews_provider.dart
+++ b/lib/presentation/pages/youtube/youtube_contents_overviews_provider.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:techtalk/core/firebase_query_constraints.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/usecases/get_youtube_overview_list_use_case.dart';
 import 'package:techtalk/features/contents/youtube.dart';
@@ -11,10 +12,13 @@ import 'package:techtalk/features/contents/youtube.dart';
 part 'youtube_contents_overviews_provider.g.dart';
 
 @riverpod
-Raw<PagingController<DocumentSnapshot<YoutubeContentsOverviewModel>?, YoutubeContentsOverviewEntity>>
-    youtubeContentsOverviews(YoutubeContentsOverviewsRef ref) {
-  final pagingController =
-      PagingController<DocumentSnapshot<YoutubeContentsOverviewModel>?, YoutubeContentsOverviewEntity>(
+Raw<
+    PagingController<DocumentSnapshot<YoutubeContentsOverviewModel>?,
+        YoutubeContentOverviewEntity>> youtubeContentsOverviews(
+    YoutubeContentsOverviewsRef ref) {
+  final pagingController = PagingController<
+      DocumentSnapshot<YoutubeContentsOverviewModel>?,
+      YoutubeContentOverviewEntity>(
     firstPageKey: null,
   );
 
@@ -26,7 +30,8 @@ Raw<PagingController<DocumentSnapshot<YoutubeContentsOverviewModel>?, YoutubeCon
       limit: 10,
       orderByField: 'upload_at',
       queryConstraints: [
-        ArrayContainsAnyConstraint(fieldPath: 'related_skill_ids', values: ['android']),
+        ArrayContainsAnyConstraint(
+            fieldPath: 'related_skill_ids', values: ['android']),
       ],
     );
 

--- a/lib/presentation/pages/youtube/youtube_contents_overviews_provider.g.dart
+++ b/lib/presentation/pages/youtube/youtube_contents_overviews_provider.g.dart
@@ -7,14 +7,14 @@ part of 'youtube_contents_overviews_provider.dart';
 // **************************************************************************
 
 String _$youtubeContentsOverviewsHash() =>
-    r'41ccd057c51a322b2035a6033bfb97ab4cb89e46';
+    r'14c1679ad11dd18b1d85dcdd822b89dad45a83a4';
 
 /// See also [youtubeContentsOverviews].
 @ProviderFor(youtubeContentsOverviews)
 final youtubeContentsOverviewsProvider = AutoDisposeProvider<
     Raw<
         PagingController<DocumentSnapshot<YoutubeContentsOverviewModel>?,
-            YoutubeContentsOverviewEntity>>>.internal(
+            YoutubeContentOverviewEntity>>>.internal(
   youtubeContentsOverviews,
   name: r'youtubeContentsOverviewsProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -27,6 +27,6 @@ final youtubeContentsOverviewsProvider = AutoDisposeProvider<
 typedef YoutubeContentsOverviewsRef = AutoDisposeProviderRef<
     Raw<
         PagingController<DocumentSnapshot<YoutubeContentsOverviewModel>?,
-            YoutubeContentsOverviewEntity>>>;
+            YoutubeContentOverviewEntity>>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/youtube/youtube_contents_overviews_provider.g.dart
+++ b/lib/presentation/pages/youtube/youtube_contents_overviews_provider.g.dart
@@ -7,7 +7,7 @@ part of 'youtube_contents_overviews_provider.dart';
 // **************************************************************************
 
 String _$youtubeContentsOverviewsHash() =>
-    r'63fd4f304892e0cfdb9e39435f1dd8a784a92254';
+    r'41ccd057c51a322b2035a6033bfb97ab4cb89e46';
 
 /// See also [youtubeContentsOverviews].
 @ProviderFor(youtubeContentsOverviews)


### PR DESCRIPTION
## 📝  무엇이 문제였나요?
- `YoutubeOverview` 컬렉션에 있는 각 document에는 유튜브 채널 정보를 적재되어 있는 `author` 필드가 존재.
- 해당 필드에는 채널의 로고, 이름 등의 정보가 포함되어 있는데, YoutubeOverview 컬렉션 모든 document가 각각 채널에 정보를 가지고 있는 형태가 변경에 대응하기 어려운 구조라고 판단함.
  - 예를들어 특정 채널의 이미지, 또는 채널명이 변경된 경우 모든  YoutubeOverview컬렉션의 모든 document를 순회하며 변경된 데이터를 업데이트 시켜주어야 함.
  
![test_overview_prev](https://github.com/user-attachments/assets/f77b99c8-8d98-40df-bb88-1d2ac3278270)




<br>

## 🔍  어떻게 해결했나요?
- ![channel_now](https://github.com/user-attachments/assets/fb610622-a5e3-4b87-9906-12c743271020)
- ![now_doc](https://github.com/user-attachments/assets/aa37dd02-dbfe-4fc5-bc39-47c480267202)
- `Channel`이라는 새로운 컬렉션을 만들어 각 유튜브 채널 정보를 저장하고,  `YoutubeOverview` 컬렉션 document들은 해당 Channel 컬렉션의 document를 `reference` 타입으로 참조하는 방식으로 변경

<br>

## 🌍 기타 변경사항
- 네이밍 수정
  - author -> channel
  - contents -> content 

- 불필요 필드 제거 (channel > homepageUrl) / 채널 id로 homePaggUrl을 특정지을 수 있기 때문
```dart
///
/// 유튜브 채널 정보
///
class ChannelEntity {
  /// 채널 id
  final String id;

  /// 채널명
  final String name;

  /// 채널의 로고 이미지
  final String? logoUrl;

  /// 채널 url
  String get url => 'https://www.youtube.com/channel/$id';

  ChannelEntity({
    required this.id,
    required this.name,
    this.logoUrl,
```

<br>

## 👥 리뷰어
@Yellowtoast , @yundal8755 

<br>


