### PR TITLE
[영상 학습] 콘텐츠 상세 정보 > firestore db 및 호출 구조 변경

### DIFF
--- a/lib/app/di/modules/youtube_di.dart
+++ b/lib/app/di/modules/youtube_di.dart
@@ -7,9 +7,11 @@ import 'package:techtalk/features/contents/usecases/get_youtube_contents_detail_
 import 'package:techtalk/features/contents/usecases/get_youtube_contents_detail_use_case.dart';
 import 'package:techtalk/features/contents/usecases/get_youtube_overview_list_use_case.dart';
 import 'package:techtalk/features/contents/youtube.dart';
+import 'package:techtalk/features/tech_set/tech_set.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
-final class YoutubeContentsDependencyInjection extends FeatureDependencyInjection {
+final class YoutubeContentsDependencyInjection
+    extends FeatureDependencyInjection {
   @override
   void dataSources() {
     locator.registerLazySingleton<YoutubeContentsRemoteDataSource>(
@@ -24,6 +26,7 @@ final class YoutubeContentsDependencyInjection extends FeatureDependencyInjectio
       () => YoutubeContentsRepositoryImpl(
         YoutubeExplode(),
         youtubeRemoteDataSource,
+        techSetRepository,
       ),
     );
   }

--- a/lib/features/chat/repositories/entities/youtube_qna_entity.dart
+++ b/lib/features/chat/repositories/entities/youtube_qna_entity.dart
@@ -8,7 +8,7 @@ import 'package:techtalk/features/topic/data_source/remote/models/topic_qna_mode
 
 class YoutubeQnaEntity extends BaseQnaEntity {
   /// 평가 요소
-  final String evaluationPoint;
+  final String? evaluationPoint;
 
   const YoutubeQnaEntity({
     required super.id,

--- a/lib/features/contents/data_source/remote/models/paragraph_model.dart
+++ b/lib/features/contents/data_source/remote/models/paragraph_model.dart
@@ -15,7 +15,7 @@ class ParagraphModel {
 
   final String title;
 
-  final String contents;
+  final List<String> contents;
 
   @DurationConverter()
   final Duration? timestamp;
@@ -36,7 +36,8 @@ class ParagraphModel {
       ParagraphModel.fromJson(snapshot.data()!);
 
   /// JSON에서 모델로 변환
-  factory ParagraphModel.fromJson(Map<String, dynamic> json) => _$ParagraphModelFromJson(json);
+  factory ParagraphModel.fromJson(Map<String, dynamic> json) =>
+      _$ParagraphModelFromJson(json);
 
   /// 모델을 JSON으로 변환
   Map<String, dynamic> toJson() => _$ParagraphModelToJson(this);

--- a/lib/features/contents/data_source/remote/models/paragraph_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/paragraph_model.g.dart
@@ -9,7 +9,8 @@ part of 'paragraph_model.dart';
 ParagraphModel _$ParagraphModelFromJson(Map<String, dynamic> json) =>
     ParagraphModel(
       title: json['title'] as String,
-      contents: json['contents'] as String,
+      contents:
+          (json['contents'] as List<dynamic>).map((e) => e as String).toList(),
       timestamp: const DurationConverter()
           .fromJson((json['timestamp'] as num?)?.toInt()),
     );

--- a/lib/features/contents/data_source/remote/models/summary_model.dart
+++ b/lib/features/contents/data_source/remote/models/summary_model.dart
@@ -13,7 +13,7 @@ class SummaryModel {
   });
 
   /// 핵심주제
-  final List<String> mainTheme;
+  final String mainTheme;
 
   /// 요약
   final List<ParagraphModel> summaries;
@@ -34,7 +34,8 @@ class SummaryModel {
       SummaryModel.fromJson(snapshot.data()!);
 
   /// JSON에서 모델로 변환
-  factory SummaryModel.fromJson(Map<String, dynamic> json) => _$SummaryModelFromJson(json);
+  factory SummaryModel.fromJson(Map<String, dynamic> json) =>
+      _$SummaryModelFromJson(json);
 
   /// 모델을 JSON으로 변환
   Map<String, dynamic> toJson() => _$SummaryModelToJson(this);

--- a/lib/features/contents/data_source/remote/models/summary_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/summary_model.g.dart
@@ -7,9 +7,7 @@ part of 'summary_model.dart';
 // **************************************************************************
 
 SummaryModel _$SummaryModelFromJson(Map<String, dynamic> json) => SummaryModel(
-      mainTheme: (json['main_theme'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
+      mainTheme: json['main_theme'] as String,
       summaries: (json['summaries'] as List<dynamic>)
           .map((e) => ParagraphModel.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/lib/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:techtalk/core/index.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
+import 'package:techtalk/features/contents/repositories/entities/youtube_contents_detail_entity.dart';
+import 'package:techtalk/features/contents/repositories/enums/contents_language.enum.dart';
+
+part 'youtube_content_detail_new_model.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+class YoutubeContentsDetailNewModel {
+  YoutubeContentsDetailNewModel({
+    required this.summary,
+  });
+
+  final SummaryModel summary;
+
+  factory YoutubeContentsDetailNewModel.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+    SnapshotOptions? options,
+  ) =>
+      YoutubeContentsDetailNewModel.fromJson(snapshot.data()!);
+
+  factory YoutubeContentsDetailNewModel.fromJson(Map<String, dynamic> json) {
+    return _$YoutubeContentsDetailNewModelFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() => _$YoutubeContentsDetailNewModelToJson(this);
+}

--- a/lib/features/contents/data_source/remote/models/youtube_content_detail_new_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_content_detail_new_model.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'youtube_content_detail_new_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+YoutubeContentsDetailNewModel _$YoutubeContentsDetailNewModelFromJson(
+        Map<String, dynamic> json) =>
+    YoutubeContentsDetailNewModel(
+      summary: SummaryModel.fromJson(json['summary'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$YoutubeContentsDetailNewModelToJson(
+        YoutubeContentsDetailNewModel instance) =>
+    <String, dynamic>{
+      'summary': instance.summary.toJson(),
+    };

--- a/lib/features/contents/data_source/remote/models/youtube_content_overview_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_content_overview_model.dart
@@ -1,8 +1,8 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:techtalk/core/constants/job_group.enum.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_overview_ref.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
+import 'package:techtalk/features/tech_set/repositories/entities/skillt_entity.dart';
 
 class YoutubeContentOverviewEntity {
   final String id;
@@ -15,7 +15,7 @@ class YoutubeContentOverviewEntity {
 
   final ChannelEntity channel;
 
-  final Set<String> relatedSkillIds;
+  final Set<SkillEntity> relatedSkillIds;
 
   final Set<JobGroup> relatedJobs;
 
@@ -44,7 +44,7 @@ class YoutubeContentOverviewEntity {
         thumbnailImgUrl: thumbnailImgUrl,
         videoDuration: videoDuration,
         qnaNum: qnaNum,
-        relatedSkillIds: relatedSkillIds.toList(),
+        relatedSkillIds: relatedSkillIds.map((skill) => skill.id).toList(),
         relatedJobGroupIds: relatedJobs.map((job) => job.id).toList(),
         channel: channel.toModel(),
         uploadAt: uploadAt,

--- a/lib/features/contents/data_source/remote/models/youtube_qna_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_qna_model.dart
@@ -1,0 +1,39 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:techtalk/features/chat/repositories/entities/youtube_qna_entity.dart';
+import 'package:techtalk/features/topic/repositories/entities/common_qna_entity.dart';
+
+part 'youtube_qna_model.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+class YoutubeQnaModel {
+  const YoutubeQnaModel({
+    required this.id,
+    required this.question,
+    required this.evaluationPoint,
+  });
+
+  final String id;
+  final String question;
+  final String? evaluationPoint;
+
+  YoutubeQnaEntity toEntity() {
+    return YoutubeQnaEntity(
+      id: id,
+      question: question,
+      evaluationPoint: evaluationPoint,
+    );
+  }
+
+  factory YoutubeQnaModel.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+    SnapshotOptions? options,
+  ) =>
+      YoutubeQnaModel.fromJson(snapshot.data()!);
+
+  factory YoutubeQnaModel.fromJson(Map<String, dynamic> json) {
+    return _$YoutubeQnaModelFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() => _$YoutubeQnaModelToJson(this);
+}

--- a/lib/features/contents/data_source/remote/models/youtube_qna_model.g.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_qna_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'youtube_qna_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+YoutubeQnaModel _$YoutubeQnaModelFromJson(Map<String, dynamic> json) =>
+    YoutubeQnaModel(
+      id: json['id'] as String,
+      question: json['question'] as String,
+      evaluationPoint: json['evaluation_point'] as String?,
+    );
+
+Map<String, dynamic> _$YoutubeQnaModelToJson(YoutubeQnaModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'question': instance.question,
+      'evaluation_point': instance.evaluationPoint,
+    };

--- a/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart
+++ b/lib/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart
@@ -6,6 +6,7 @@ import 'package:techtalk/features/contents/data_source/remote/models/contents_au
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_author_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
+import 'package:techtalk/features/tech_set/repositories/entities/skillt_entity.dart';
 
 part 'youtube_video_contents_overview_model.g.dart';
 
@@ -54,14 +55,14 @@ class YoutubeContentsOverviewModel {
   final ChannelModel? channel;
 
   /// 엔티티로 변환
-  YoutubeContentOverviewEntity toEntity() {
+  YoutubeContentOverviewEntity toEntity(List<SkillEntity> skills) {
     return YoutubeContentOverviewEntity(
       id: id,
       thumbnailImgUrl: thumbnailImgUrl,
       contentsTitle: contentsTitle,
       qnaNum: qnaNum,
       channel: channel?.toEntity() ?? ChannelEntity.undefined(),
-      relatedSkillIds: relatedSkillIds.toSet(),
+      relatedSkillIds: skills.toSet(),
       relatedJobs: relatedJobGroupIds.map(JobGroup.getById).toSet(),
       videoDuration: videoDuration,
       uploadAt: uploadAt,

--- a/lib/features/contents/data_source/remote/youtube_contents_detail_ref.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_detail_ref.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_contents_detail_model.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
@@ -12,7 +13,10 @@ abstract class FirestoreYoutubeDetailRef {
           );
 
   static DocumentReference<YoutubeContentsDetailModel> doc(String contentsId) =>
-      FirebaseFirestore.instance.collection(_collectionName).doc(contentsId).withConverter(
+      FirebaseFirestore.instance
+          .collection(_collectionName)
+          .doc(contentsId)
+          .withConverter(
             fromFirestore: YoutubeContentsDetailModel.fromFirestore,
             toFirestore: (value, options) => value.toJson(),
           );
@@ -32,15 +36,22 @@ abstract class FirestoreYoutubeDetailQuestionRef {
 }
 
 @override
-Future<void> addYoutubeContentsDetail(String contentsId, YoutubeContentsDetailModel detailModel) async {
-  final ref = FirebaseFirestore.instance.collection('YoutubeDetail').doc(contentsId);
+Future<void> addYoutubeContentsDetail(
+    String contentsId, YoutubeContentsDetailModel detailModel) async {
+  final ref =
+      FirebaseFirestore.instance.collection('YoutubeDetail').doc(contentsId);
 
   await ref.set(detailModel.toJson());
 }
 
 @override
-Future<void> addYoutubeContentsQnas(String contentsId, List<TopicQnaModel> qnas) async {
+Future<void> addYoutubeContentsQnas(
+    String contentsId, List<TopicQnaModel> qnas) async {
   for (var qna in qnas) {
-    await FirebaseFirestore.instance.collection('YoutubeDetail').doc(contentsId).collection('Qna').add(qna.toJson());
+    await FirebaseFirestore.instance
+        .collection('YoutubeDetail')
+        .doc(contentsId)
+        .collection('Qna')
+        .add(qna.toJson());
   }
 }

--- a/lib/features/contents/data_source/remote/youtube_contents_overview_ref.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_overview_ref.dart
@@ -1,18 +1,20 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 
 abstract class FirestoreYoutubeContentsOverviewRef {
-  static const String _collectionName = 'YoutubeOverview';
+  static const String collectionName = 'YoutubeOverview';
 
   static CollectionReference<YoutubeContentsOverviewModel> collection() =>
-      FirebaseFirestore.instance.collection(_collectionName).withConverter(
+      FirebaseFirestore.instance.collection(collectionName).withConverter(
             fromFirestore: YoutubeContentsOverviewModel.fromFirestore,
             toFirestore: (value, options) => value.toJson(),
           );
 
   static DocumentReference<YoutubeContentsOverviewModel> doc(String id) =>
       FirebaseFirestore.instance
-          .collection(_collectionName)
+          .collection(collectionName)
           .doc(id)
           .withConverter(
             fromFirestore: YoutubeContentsOverviewModel.fromFirestore,
@@ -21,6 +23,25 @@ abstract class FirestoreYoutubeContentsOverviewRef {
 
   static DocumentReference channelDocumentRef(String channelId) =>
       FirebaseFirestore.instance.collection('Channel').doc(channelId);
+}
+
+///
+/// 특정 유튜브 상세(서머리) ref
+///
+abstract class FirestoreYoutubeDetailNewRef {
+  static const String name = 'Detail';
+
+  static DocumentReference<YoutubeContentsDetailNewModel> collection(
+          String contentsId) =>
+      FirebaseFirestore.instance
+          .collection(FirestoreYoutubeContentsOverviewRef.collectionName)
+          .doc(contentsId)
+          .collection(name)
+          .doc(contentsId)
+          .withConverter(
+            fromFirestore: YoutubeContentsDetailNewModel.fromFirestore,
+            toFirestore: (value, options) => value.toJson(),
+          );
 }
 
 @override

--- a/lib/features/contents/data_source/remote/youtube_contents_overview_ref.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_overview_ref.dart
@@ -1,7 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_qna_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
+import 'package:techtalk/features/topic/data_source/remote/models/topic_qna_model.dart';
 
 abstract class FirestoreYoutubeContentsOverviewRef {
   static const String collectionName = 'YoutubeOverview';
@@ -26,29 +28,47 @@ abstract class FirestoreYoutubeContentsOverviewRef {
 }
 
 ///
-/// 특정 유튜브 상세(서머리) ref
+/// 유튜브 콘텐츠 상세(서머리) ref
 ///
 abstract class FirestoreYoutubeDetailNewRef {
   static const String name = 'Detail';
 
   static DocumentReference<YoutubeContentsDetailNewModel> collection(
-          String contentsId) =>
+          String contentId) =>
       FirebaseFirestore.instance
           .collection(FirestoreYoutubeContentsOverviewRef.collectionName)
-          .doc(contentsId)
+          .doc(contentId)
           .collection(name)
-          .doc(contentsId)
+          .doc(contentId)
           .withConverter(
             fromFirestore: YoutubeContentsDetailNewModel.fromFirestore,
             toFirestore: (value, options) => value.toJson(),
           );
 }
 
-@override
-Future<void> addYoutubeContentsOverview(
-    String contentsId, YoutubeContentsOverviewModel overviewModel) async {
-  final ref =
-      FirebaseFirestore.instance.collection('YoutubeOverview').doc(contentsId);
+///
+/// 유트브 콘텐츠 문답
+///
+abstract class FirestoreYoutubeQnaNewRef {
+  static const String name = 'Qna';
 
-  await ref.set(overviewModel.toJson());
+  static CollectionReference<YoutubeQnaModel> collection(String contentsId) =>
+      FirebaseFirestore.instance
+          .collection(FirestoreYoutubeContentsOverviewRef.collectionName)
+          .doc(contentsId)
+          .collection(name)
+          .withConverter(
+            fromFirestore: YoutubeQnaModel.fromFirestore,
+            toFirestore: (value, options) => value.toJson(),
+          );
+
+  @override
+  Future<void> addYoutubeContentsOverview(
+      String contentsId, YoutubeContentsOverviewModel overviewModel) async {
+    final ref = FirebaseFirestore.instance
+        .collection('YoutubeOverview')
+        .doc(contentsId);
+
+    await ref.set(overviewModel.toJson());
+  }
 }

--- a/lib/features/contents/data_source/remote/youtube_contents_remote_data_source.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_remote_data_source.dart
@@ -3,6 +3,7 @@ import 'package:techtalk/core/firebase_pagination_result.dart';
 import 'package:techtalk/core/firebase_query_constraints.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_contents_detail_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_qna_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/topic/topic.dart';
 
@@ -13,14 +14,20 @@ abstract interface class YoutubeContentsRemoteDataSource {
   ///
   /// [contentsId] - 조회할 컨텐츠의 고유 ID
   ///
+  @Deprecated('[YoutubeContentsDetailNewModel]로 교체 예정')
   Future<YoutubeContentsDetailModel> getYoutubeContentsDetail(
       String contentsId);
 
   ///
-  /// 유튜브 콘텐츠 상세 정보를 가져옴
+  /// 유튜브 콘텐츠 qna 호출
+  ///
+  Future<List<YoutubeQnaModel>> getQnas(String contentId);
+
+  ///
+  /// 유튜브 콘텐츠 상세 정보 호출
   /// (현재는 상세 정보에 요약 정보밖에 존재하지 않음)
   ///
-  Future<YoutubeContentsDetailNewModel> getContentDetail(String contentId);
+  Future<YoutubeContentsDetailNewModel> getDetail(String contentId);
 
   ///
   /// 특정 유튜브 컨텐츠와 관련된 질문 목록을 가져옵니다.

--- a/lib/features/contents/data_source/remote/youtube_contents_remote_data_source.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_remote_data_source.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:techtalk/core/firebase_pagination_result.dart';
 import 'package:techtalk/core/firebase_query_constraints.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_contents_detail_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/topic/topic.dart';
@@ -12,7 +13,14 @@ abstract interface class YoutubeContentsRemoteDataSource {
   ///
   /// [contentsId] - 조회할 컨텐츠의 고유 ID
   ///
-  Future<YoutubeContentsDetailModel> getYoutubeContentsDetail(String contentsId);
+  Future<YoutubeContentsDetailModel> getYoutubeContentsDetail(
+      String contentsId);
+
+  ///
+  /// 유튜브 콘텐츠 상세 정보를 가져옴
+  /// (현재는 상세 정보에 요약 정보밖에 존재하지 않음)
+  ///
+  Future<YoutubeContentsDetailNewModel> getContentDetail(String contentId);
 
   ///
   /// 특정 유튜브 컨텐츠와 관련된 질문 목록을 가져옵니다.
@@ -28,8 +36,9 @@ abstract interface class YoutubeContentsRemoteDataSource {
   /// [limit] - 한 페이지당 가져올 항목 수
   /// [queryConstraints] - 추가적인 쿼리 제약 조건
   ///
-  Future<FirebasePaginatedResult<YoutubeContentsOverviewModel, YoutubeContentsOverviewModel>>
-      getYoutubeContentsOverviews({
+  Future<
+      FirebasePaginatedResult<YoutubeContentsOverviewModel,
+          YoutubeContentsOverviewModel>> getYoutubeContentsOverviews({
     required int limit,
     required String orderByField,
     DocumentSnapshot<YoutubeContentsOverviewModel>? lastDocument,

--- a/lib/features/contents/data_source/remote/youtube_contents_remote_data_source_impl.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_remote_data_source_impl.dart
@@ -7,6 +7,7 @@ import 'package:techtalk/features/contents/data_source/remote/models/contents_au
 import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_contents_detail_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_qna_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_detail_ref.dart';
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_overview_ref.dart';
@@ -105,8 +106,7 @@ final class YoutubeContentsRemoteDataSourceImpl
   }
 
   @override
-  Future<YoutubeContentsDetailNewModel> getContentDetail(
-      String contentId) async {
+  Future<YoutubeContentsDetailNewModel> getDetail(String contentId) async {
     try {
       final doc =
           await FirestoreYoutubeDetailNewRef.collection(contentId).get();
@@ -115,6 +115,18 @@ final class YoutubeContentsRemoteDataSourceImpl
       }
 
       return doc.data()!;
+    } catch (e) {
+      throw Exception('Failed to fetch Youtube Contents: $e');
+    }
+  }
+
+  @override
+  Future<List<YoutubeQnaModel>> getQnas(String contentId) async {
+    try {
+      final collection =
+          await FirestoreYoutubeQnaNewRef.collection(contentId).get();
+
+      return collection.docs.map((doc) => doc.data()).toList();
     } catch (e) {
       throw Exception('Failed to fetch Youtube Contents: $e');
     }

--- a/lib/features/contents/data_source/remote/youtube_contents_remote_data_source_impl.dart
+++ b/lib/features/contents/data_source/remote/youtube_contents_remote_data_source_impl.dart
@@ -4,6 +4,8 @@ import 'package:techtalk/core/firebase_query_constraints.dart';
 import 'package:techtalk/core/index.dart';
 import 'package:techtalk/core/query_constraints_applier.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/contents_author_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_detail_new_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_contents_detail_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_detail_ref.dart';
@@ -97,6 +99,22 @@ final class YoutubeContentsRemoteDataSourceImpl
         lastDocument: newLastDocument,
         hasMore: hasMore,
       );
+    } catch (e) {
+      throw Exception('Failed to fetch Youtube Contents: $e');
+    }
+  }
+
+  @override
+  Future<YoutubeContentsDetailNewModel> getContentDetail(
+      String contentId) async {
+    try {
+      final doc =
+          await FirestoreYoutubeDetailNewRef.collection(contentId).get();
+      if (!doc.exists) {
+        throw const FetchYoutubeContentsDetailException();
+      }
+
+      return doc.data()!;
     } catch (e) {
       throw Exception('Failed to fetch Youtube Contents: $e');
     }

--- a/lib/features/contents/repositories/entities/paragraph_entity.dart
+++ b/lib/features/contents/repositories/entities/paragraph_entity.dart
@@ -6,7 +6,7 @@ class ParagraphEntity {
   final String title;
 
   /// 문단 내용
-  final String contents;
+  final List<String> contents;
 
   /// 해당 문단의 시작 시간
   final Duration? timestamp;

--- a/lib/features/contents/repositories/entities/summary_entity.dart
+++ b/lib/features/contents/repositories/entities/summary_entity.dart
@@ -4,7 +4,7 @@ import 'package:techtalk/features/contents/repositories/entities/paragraph_entit
 /// 요약 엔티티
 class SummaryEntity {
   /// 핵심 요약
-  final List<String> mainTheme;
+  final String mainTheme;
 
   /// 요약 노트
   final List<ParagraphEntity> summaryNotes;

--- a/lib/features/contents/repositories/entities/youtube_contents_detail_entity.dart
+++ b/lib/features/contents/repositories/entities/youtube_contents_detail_entity.dart
@@ -57,7 +57,8 @@ class YoutubeContentsDetailEntity {
         authorId: authorId,
         relatedSkillIds: relatedSkillIds.toList(),
         relatedJobGroupIds: relatedJobs.map((job) => job.id).toList(),
-        contentsLanguageIds: contentsLanguage.map((language) => language.id).toList(),
+        contentsLanguageIds:
+            contentsLanguage.map((language) => language.id).toList(),
         summary: summary.toModel(),
         createdAt: createdAt,
         uploadAt: uploadAt,

--- a/lib/features/contents/repositories/youtube_contents_repository.dart
+++ b/lib/features/contents/repositories/youtube_contents_repository.dart
@@ -6,9 +6,11 @@ import 'package:techtalk/core/firebase_query_constraints.dart';
 import 'package:techtalk/core/modules/error_handling/result.dart';
 import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/features/chat/repositories/entities/youtube_qna_entity.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
+import 'package:techtalk/features/contents/repositories/entities/summary_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_contents_detail_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_video_data_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
@@ -20,6 +22,11 @@ abstract interface class YoutubeContentsRepository {
   Future<Result<YouTubeVideoDataEntity>> getYoutubeVideoData(
     String videoId,
   );
+
+  ///
+  /// 유튜브 콘텐츠의 요약 정보를 가져옴
+  ///
+  Future<Result<SummaryEntity>> getYoutubeSummary(String contentId);
 
   ///
   /// 유튜브 컨텐츠 상세 정보 가져오기

--- a/lib/features/contents/repositories/youtube_contents_repository.dart
+++ b/lib/features/contents/repositories/youtube_contents_repository.dart
@@ -24,9 +24,14 @@ abstract interface class YoutubeContentsRepository {
   );
 
   ///
-  /// 유튜브 콘텐츠의 요약 정보를 가져옴
+  /// 유튜브 콘텐츠의 요약 정보 호출
   ///
   Future<Result<SummaryEntity>> getYoutubeSummary(String contentId);
+
+  ///
+  /// 유튜브 콘텐츠 qna 호출
+  ///
+  Future<Result<List<YoutubeQnaEntity>>> getQnas(String contentId);
 
   ///
   /// 유튜브 컨텐츠 상세 정보 가져오기

--- a/lib/features/contents/repositories/youtube_contents_repository_impl.dart
+++ b/lib/features/contents/repositories/youtube_contents_repository_impl.dart
@@ -16,15 +16,17 @@ import 'package:techtalk/features/contents/repositories/entities/contents_overvi
 import 'package:techtalk/features/contents/repositories/entities/youtube_contents_detail_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_video_data_entity.dart';
 import 'package:techtalk/features/contents/repositories/youtube_contents_repository.dart';
+import 'package:techtalk/features/tech_set/repositories/tech_set_repository.dart';
 import 'package:techtalk/features/topic/topic.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
 class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
-  YoutubeContentsRepositoryImpl(
-      this._youtubeApiDataSource, this._youtubeRemoteDataSource);
+  YoutubeContentsRepositoryImpl(this._youtubeApiDataSource,
+      this._youtubeRemoteDataSource, this._techSetRepository);
 
   final YoutubeExplode _youtubeApiDataSource;
   final YoutubeContentsRemoteDataSource _youtubeRemoteDataSource;
+  final TechSetRepository _techSetRepository;
 
   @override
   Future<Result<YouTubeVideoDataEntity>> getYoutubeVideoData(
@@ -105,8 +107,11 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
       );
 
       // 모델을 엔티티로 변환
-      final entities =
-          remotePaginatedResult.items.map((model) => model.toEntity()).toList();
+      final entities = remotePaginatedResult.items.map((model) {
+        final skills =
+            model.relatedSkillIds.map(_techSetRepository.getSkillById).toList();
+        return model.toEntity(skills);
+      }).toList();
 
       // 엔티티로 페이징된 결과 생성
       final paginatedResult = FirebasePaginatedResult<

--- a/lib/features/contents/repositories/youtube_contents_repository_impl.dart
+++ b/lib/features/contents/repositories/youtube_contents_repository_impl.dart
@@ -135,10 +135,21 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
   @override
   Future<Result<SummaryEntity>> getYoutubeSummary(String contentId) async {
     try {
-      final response =
-          await _youtubeRemoteDataSource.getContentDetail(contentId);
+      final response = await _youtubeRemoteDataSource.getDetail(contentId);
 
       final result = response.summary.toEntity();
+
+      return Result.success(result);
+    } on Exception catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  @override
+  Future<Result<List<YoutubeQnaEntity>>> getQnas(String contentId) async {
+    try {
+      final response = await _youtubeRemoteDataSource.getQnas(contentId);
+      final result = response.map((e) => e.toEntity()).toList();
 
       return Result.success(result);
     } on Exception catch (e) {

--- a/lib/features/contents/repositories/youtube_contents_repository_impl.dart
+++ b/lib/features/contents/repositories/youtube_contents_repository_impl.dart
@@ -9,10 +9,12 @@ import 'package:techtalk/core/modules/error_handling/result.dart';
 import 'package:techtalk/core/modules/exceptions/custom_exception.dart';
 import 'package:techtalk/features/chat/repositories/entities/resume_qna_entity.dart';
 import 'package:techtalk/features/chat/repositories/entities/youtube_qna_entity.dart';
+import 'package:techtalk/features/contents/data_source/remote/models/summary_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_content_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/models/youtube_video_contents_overview_model.dart';
 import 'package:techtalk/features/contents/data_source/remote/youtube_contents_remote_data_source.dart';
 import 'package:techtalk/features/contents/repositories/entities/contents_overview_entity.dart';
+import 'package:techtalk/features/contents/repositories/entities/summary_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_contents_detail_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_video_data_entity.dart';
 import 'package:techtalk/features/contents/repositories/youtube_contents_repository.dart';
@@ -127,6 +129,20 @@ class YoutubeContentsRepositoryImpl implements YoutubeContentsRepository {
       return Result.failure(
         const FetchYoutubeContentsOverviewException(),
       );
+    }
+  }
+
+  @override
+  Future<Result<SummaryEntity>> getYoutubeSummary(String contentId) async {
+    try {
+      final response =
+          await _youtubeRemoteDataSource.getContentDetail(contentId);
+
+      final result = response.summary.toEntity();
+
+      return Result.success(result);
+    } on Exception catch (e) {
+      return Result.failure(e);
     }
   }
 }

--- a/lib/presentation/pages/youtube/detail/providers/youtube_content_qna_provider.dart
+++ b/lib/presentation/pages/youtube/detail/providers/youtube_content_qna_provider.dart
@@ -1,0 +1,21 @@
+import 'dart:developer';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:techtalk/features/chat/repositories/entities/youtube_qna_entity.dart';
+import 'package:techtalk/features/contents/youtube.dart';
+
+part 'youtube_content_qna_provider.g.dart';
+
+@riverpod
+class YoutubeContentQna extends _$YoutubeContentQna {
+  @override
+  FutureOr<List<YoutubeQnaEntity>> build(String contentId) async {
+    final response = await youtubeRepository.getQnas(contentId);
+    return response.fold(
+        onSuccess: (qnas) => qnas,
+        onFailure: (e) {
+          log('유튜브 콘텐츠 qna 정보 호출 실패 : $e');
+          throw e;
+        });
+  }
+}

--- a/lib/presentation/pages/youtube/detail/providers/youtube_content_qna_provider.g.dart
+++ b/lib/presentation/pages/youtube/detail/providers/youtube_content_qna_provider.g.dart
@@ -1,0 +1,176 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'youtube_content_qna_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$youtubeContentQnaHash() => r'56ece84355eff30053af464c3725ffb2ce6e590f';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$YoutubeContentQna
+    extends BuildlessAutoDisposeAsyncNotifier<List<YoutubeQnaEntity>> {
+  late final String contentId;
+
+  FutureOr<List<YoutubeQnaEntity>> build(
+    String contentId,
+  );
+}
+
+/// See also [YoutubeContentQna].
+@ProviderFor(YoutubeContentQna)
+const youtubeContentQnaProvider = YoutubeContentQnaFamily();
+
+/// See also [YoutubeContentQna].
+class YoutubeContentQnaFamily
+    extends Family<AsyncValue<List<YoutubeQnaEntity>>> {
+  /// See also [YoutubeContentQna].
+  const YoutubeContentQnaFamily();
+
+  /// See also [YoutubeContentQna].
+  YoutubeContentQnaProvider call(
+    String contentId,
+  ) {
+    return YoutubeContentQnaProvider(
+      contentId,
+    );
+  }
+
+  @override
+  YoutubeContentQnaProvider getProviderOverride(
+    covariant YoutubeContentQnaProvider provider,
+  ) {
+    return call(
+      provider.contentId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'youtubeContentQnaProvider';
+}
+
+/// See also [YoutubeContentQna].
+class YoutubeContentQnaProvider extends AutoDisposeAsyncNotifierProviderImpl<
+    YoutubeContentQna, List<YoutubeQnaEntity>> {
+  /// See also [YoutubeContentQna].
+  YoutubeContentQnaProvider(
+    String contentId,
+  ) : this._internal(
+          () => YoutubeContentQna()..contentId = contentId,
+          from: youtubeContentQnaProvider,
+          name: r'youtubeContentQnaProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$youtubeContentQnaHash,
+          dependencies: YoutubeContentQnaFamily._dependencies,
+          allTransitiveDependencies:
+              YoutubeContentQnaFamily._allTransitiveDependencies,
+          contentId: contentId,
+        );
+
+  YoutubeContentQnaProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.contentId,
+  }) : super.internal();
+
+  final String contentId;
+
+  @override
+  FutureOr<List<YoutubeQnaEntity>> runNotifierBuild(
+    covariant YoutubeContentQna notifier,
+  ) {
+    return notifier.build(
+      contentId,
+    );
+  }
+
+  @override
+  Override overrideWith(YoutubeContentQna Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: YoutubeContentQnaProvider._internal(
+        () => create()..contentId = contentId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        contentId: contentId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<YoutubeContentQna,
+      List<YoutubeQnaEntity>> createElement() {
+    return _YoutubeContentQnaProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is YoutubeContentQnaProvider && other.contentId == contentId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, contentId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin YoutubeContentQnaRef
+    on AutoDisposeAsyncNotifierProviderRef<List<YoutubeQnaEntity>> {
+  /// The parameter `contentId` of this provider.
+  String get contentId;
+}
+
+class _YoutubeContentQnaProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<YoutubeContentQna,
+        List<YoutubeQnaEntity>> with YoutubeContentQnaRef {
+  _YoutubeContentQnaProviderElement(super.provider);
+
+  @override
+  String get contentId => (origin as YoutubeContentQnaProvider).contentId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/youtube/detail/providers/youtube_summary_provider.dart
+++ b/lib/presentation/pages/youtube/detail/providers/youtube_summary_provider.dart
@@ -1,0 +1,20 @@
+import 'dart:developer';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:techtalk/features/contents/youtube.dart';
+
+part 'youtube_summary_provider.g.dart';
+
+@riverpod
+class YoutubeSummary extends _$YoutubeSummary {
+  @override
+  FutureOr<SummaryEntity> build(String contentId) async {
+    final response = await youtubeRepository.getYoutubeSummary(contentId);
+
+    return response.fold(onSuccess: (e) {
+      return e;
+    }, onFailure: (e) {
+      log('유튜브 요약 정보 호출 실패 : $e');
+      throw e;
+    });
+  }
+}

--- a/lib/presentation/pages/youtube/detail/providers/youtube_summary_provider.g.dart
+++ b/lib/presentation/pages/youtube/detail/providers/youtube_summary_provider.g.dart
@@ -1,0 +1,174 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'youtube_summary_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$youtubeSummaryHash() => r'3e2271be3af1c5486221e64f37595181b09a119b';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$YoutubeSummary
+    extends BuildlessAutoDisposeAsyncNotifier<SummaryEntity> {
+  late final String contentId;
+
+  FutureOr<SummaryEntity> build(
+    String contentId,
+  );
+}
+
+/// See also [YoutubeSummary].
+@ProviderFor(YoutubeSummary)
+const youtubeSummaryProvider = YoutubeSummaryFamily();
+
+/// See also [YoutubeSummary].
+class YoutubeSummaryFamily extends Family<AsyncValue<SummaryEntity>> {
+  /// See also [YoutubeSummary].
+  const YoutubeSummaryFamily();
+
+  /// See also [YoutubeSummary].
+  YoutubeSummaryProvider call(
+    String contentId,
+  ) {
+    return YoutubeSummaryProvider(
+      contentId,
+    );
+  }
+
+  @override
+  YoutubeSummaryProvider getProviderOverride(
+    covariant YoutubeSummaryProvider provider,
+  ) {
+    return call(
+      provider.contentId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'youtubeSummaryProvider';
+}
+
+/// See also [YoutubeSummary].
+class YoutubeSummaryProvider extends AutoDisposeAsyncNotifierProviderImpl<
+    YoutubeSummary, SummaryEntity> {
+  /// See also [YoutubeSummary].
+  YoutubeSummaryProvider(
+    String contentId,
+  ) : this._internal(
+          () => YoutubeSummary()..contentId = contentId,
+          from: youtubeSummaryProvider,
+          name: r'youtubeSummaryProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$youtubeSummaryHash,
+          dependencies: YoutubeSummaryFamily._dependencies,
+          allTransitiveDependencies:
+              YoutubeSummaryFamily._allTransitiveDependencies,
+          contentId: contentId,
+        );
+
+  YoutubeSummaryProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.contentId,
+  }) : super.internal();
+
+  final String contentId;
+
+  @override
+  FutureOr<SummaryEntity> runNotifierBuild(
+    covariant YoutubeSummary notifier,
+  ) {
+    return notifier.build(
+      contentId,
+    );
+  }
+
+  @override
+  Override overrideWith(YoutubeSummary Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: YoutubeSummaryProvider._internal(
+        () => create()..contentId = contentId,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        contentId: contentId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<YoutubeSummary, SummaryEntity>
+      createElement() {
+    return _YoutubeSummaryProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is YoutubeSummaryProvider && other.contentId == contentId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, contentId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin YoutubeSummaryRef on AutoDisposeAsyncNotifierProviderRef<SummaryEntity> {
+  /// The parameter `contentId` of this provider.
+  String get contentId;
+}
+
+class _YoutubeSummaryProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<YoutubeSummary,
+        SummaryEntity> with YoutubeSummaryRef {
+  _YoutubeSummaryProviderElement(super.provider);
+
+  @override
+  String get contentId => (origin as YoutubeSummaryProvider).contentId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/presentation/pages/youtube/detail/widgets/summary_note_foldable_item.dart
+++ b/lib/presentation/pages/youtube/detail/widgets/summary_note_foldable_item.dart
@@ -15,7 +15,7 @@ class SummaryNoteFoldableItem extends HookWidget {
 
   final Duration? timestamp;
   final String title;
-  final String contents;
+  final List<String> contents;
   final void Function(Duration?)? onTapTimestamp;
   final double height;
 
@@ -60,11 +60,16 @@ class SummaryNoteFoldableItem extends HookWidget {
             duration: const Duration(milliseconds: 300),
             curve: Curves.fastOutSlowIn,
             child: ConstrainedBox(
-              constraints: isExpanded.value ? const BoxConstraints() : const BoxConstraints(maxHeight: 0),
+              constraints: isExpanded.value
+                  ? const BoxConstraints()
+                  : const BoxConstraints(maxHeight: 0),
               child: Padding(
                 padding: const EdgeInsets.only(top: 8.0),
-                child: Text(
-                  contents,
+                child: Wrap(
+                  direction: Axis.vertical,
+                  children: [
+                    ...contents.map((e) => Text(e)),
+                  ],
                 ),
               ),
             ),

--- a/lib/presentation/pages/youtube/detail/youtube_contents_detail_page.dart
+++ b/lib/presentation/pages/youtube/detail/youtube_contents_detail_page.dart
@@ -139,7 +139,7 @@ class YoutubeContentsDetailPage extends BasePage
                       spacing: 8.0,
                       children: overview.relatedSkillIds
                           .map(
-                            (skill) => Chip(label: Text(skill)),
+                            (skill) => Chip(label: Text(skill.name)),
                           )
                           .toList(),
                     ),

--- a/lib/presentation/pages/youtube/detail/youtube_contents_detail_page.dart
+++ b/lib/presentation/pages/youtube/detail/youtube_contents_detail_page.dart
@@ -30,32 +30,32 @@ class YoutubeContentsDetailPage extends BasePage
         body: NestedScrollView(
           headerSliverBuilder: (context, innerBoxIsScrolled) => [
             // AppBar 대체
-            // SliverAppBar(
-            //   leading: const AppBackButton(),
-            //   titleSpacing: 0,
-            //   backgroundColor: AppColor.of.white,
-            //   pinned: true,
-            //   expandedHeight: 210.0,
-            //   flexibleSpace: FlexibleSpaceBar(
-            //     background: AsyncSkeletonWidgetBuilder(
-            //       asyncValue: youtubeVideoDataAsync(ref, overview.id),
-            //       skeletonBuilder: (p0) => SizedBox(
-            //         height: 210,
-            //         width: double.infinity,
-            //         child: SkeletonBox(),
-            //       ),
-            //       dataBuilder: (context, data) => SizedBox(
-            //         height: 210,
-            //         width: double.infinity,
-            //         // TODO: 이미지 캐싱 기능 구현
-            //         child: Image.network(
-            //           data.thumnailSet.lowResUrl,
-            //           fit: BoxFit.cover,
-            //         ),
-            //       ),
-            //     ),
-            //   ),
-            // ),
+            SliverAppBar(
+              leading: const AppBackButton(),
+              titleSpacing: 0,
+              backgroundColor: AppColor.of.white,
+              pinned: true,
+              expandedHeight: 210.0,
+              flexibleSpace: FlexibleSpaceBar(
+                background: AsyncSkeletonWidgetBuilder(
+                  asyncValue: youtubeVideoDataAsync(ref, overview.id),
+                  skeletonBuilder: (p0) => SizedBox(
+                    height: 210,
+                    width: double.infinity,
+                    child: SkeletonBox(),
+                  ),
+                  dataBuilder: (context, data) => SizedBox(
+                    height: 210,
+                    width: double.infinity,
+                    // TODO: 이미지 캐싱 기능 구현
+                    child: Image.network(
+                      data.thumnailSet.lowResUrl,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+              ),
+            ),
             // 콘텐츠 영역을 SliverToBoxAdapter로 감싸기
             SliverToBoxAdapter(
               child: Padding(
@@ -235,8 +235,7 @@ class YoutubeContentsDetailPage extends BasePage
                 padding: const EdgeInsets.all(16),
                 children: [
                   AsyncSkeletonWidgetBuilder(
-                    asyncValue:
-                        youtubeContentsDetailQnasAsync(ref, overview.id),
+                    asyncValue: qnasAsync(ref, contentId: overview.id),
                     skeletonBuilder: (p0) => const Center(
                       child: CircularProgressIndicator(),
                     ),

--- a/lib/presentation/pages/youtube/detail/youtube_contents_detail_page.dart
+++ b/lib/presentation/pages/youtube/detail/youtube_contents_detail_page.dart
@@ -30,35 +30,32 @@ class YoutubeContentsDetailPage extends BasePage
         body: NestedScrollView(
           headerSliverBuilder: (context, innerBoxIsScrolled) => [
             // AppBar 대체
-            SliverAppBar(
-              leading: const AppBackButton(),
-              titleSpacing: 0,
-              backgroundColor: AppColor.of.white,
-              pinned: true,
-              expandedHeight: 210.0,
-              flexibleSpace: FlexibleSpaceBar(
-                background: AsyncSkeletonWidgetBuilder(
-                  asyncValue: youtubeVideoDataAsync(ref, overview.id),
-                  skeletonBuilder: (p0) => SizedBox(
-                    height: 210,
-                    width: double.infinity,
-                    child: Image.network(
-                      overview.thumbnailImgUrl,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
-                  dataBuilder: (context, data) => SizedBox(
-                    height: 210,
-                    width: double.infinity,
-                    // TODO: 이미지 캐싱 기능 구현
-                    child: Image.network(
-                      data.thumnailSet.highResUrl,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
-                ),
-              ),
-            ),
+            // SliverAppBar(
+            //   leading: const AppBackButton(),
+            //   titleSpacing: 0,
+            //   backgroundColor: AppColor.of.white,
+            //   pinned: true,
+            //   expandedHeight: 210.0,
+            //   flexibleSpace: FlexibleSpaceBar(
+            //     background: AsyncSkeletonWidgetBuilder(
+            //       asyncValue: youtubeVideoDataAsync(ref, overview.id),
+            //       skeletonBuilder: (p0) => SizedBox(
+            //         height: 210,
+            //         width: double.infinity,
+            //         child: SkeletonBox(),
+            //       ),
+            //       dataBuilder: (context, data) => SizedBox(
+            //         height: 210,
+            //         width: double.infinity,
+            //         // TODO: 이미지 캐싱 기능 구현
+            //         child: Image.network(
+            //           data.thumnailSet.lowResUrl,
+            //           fit: BoxFit.cover,
+            //         ),
+            //       ),
+            //     ),
+            //   ),
+            // ),
             // 콘텐츠 영역을 SliverToBoxAdapter로 감싸기
             SliverToBoxAdapter(
               child: Padding(
@@ -173,64 +170,65 @@ class YoutubeContentsDetailPage extends BasePage
             children: [
               // 첫 번째 탭 내용
               // 각 탭의 내용을 스크롤 가능한 위젯으로 감싸기
-              ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  AsyncSkeletonWidgetBuilder(
-                    asyncValue: youtubeContentsDetailAsync(ref, overview.id),
-                    skeletonBuilder: (p0) => const Center(
-                      child: CircularProgressIndicator(),
-                    ),
-                    dataBuilder: (context, data) => Wrap(
-                      runSpacing: 50,
-                      children: [
-                        if (data.summary.mainTheme.isNotEmpty)
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                '핵심 주제',
-                              ),
-                              const SizedBox(height: 8),
-                              ...data.summary.mainTheme
-                                  .map(
-                                    (contents) => Text(
-                                      contents,
-                                    ),
-                                  )
-                                  .toList(),
-                            ],
-                          ),
-                        if (data.summary.summaryNotes.isNotEmpty)
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                '요약 노트',
-                              ),
-                              SizedBox(
-                                height: 15,
-                              ),
-                              Wrap(
-                                runSpacing: 10,
+              Consumer(
+                builder: (context, ref, _) {
+                  final targetAsync = summaryAsync(ref, contentId: overview.id);
+
+                  return ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      AsyncSkeletonWidgetBuilder(
+                        asyncValue: targetAsync,
+                        skeletonBuilder: (p0) => const Center(
+                          child: CircularProgressIndicator(),
+                        ),
+                        dataBuilder: (context, data) => Wrap(
+                          runSpacing: 50,
+                          children: [
+                            if (data.mainTheme.isNotEmpty)
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  ...data.summary.summaryNotes
-                                      .map(
-                                        (summary) => SummaryNoteFoldableItem(
-                                          timestamp: summary.timestamp,
-                                          title: summary.title,
-                                          contents: summary.contents,
-                                        ),
-                                      )
-                                      .toList(),
+                                  Text(
+                                    '핵심 주제',
+                                  ),
+                                  const SizedBox(height: 8),
+                                  Text(data.mainTheme),
                                 ],
-                              )
-                            ],
-                          ),
-                      ],
-                    ),
-                  ),
-                ],
+                              ),
+                            if (data.summaryNotes.isNotEmpty)
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    '요약 노트',
+                                  ),
+                                  SizedBox(
+                                    height: 15,
+                                  ),
+                                  Wrap(
+                                    runSpacing: 10,
+                                    children: [
+                                      ...data.summaryNotes
+                                          .map(
+                                            (summary) =>
+                                                SummaryNoteFoldableItem(
+                                              timestamp: summary.timestamp,
+                                              title: summary.title,
+                                              contents: summary.contents,
+                                            ),
+                                          )
+                                          .toList(),
+                                    ],
+                                  )
+                                ],
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  );
+                },
               ),
               // 두 번째 탭 내용
               ListView(
@@ -291,6 +289,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   double get minExtent => _tabBar.preferredSize.height;
+
   @override
   double get maxExtent => _tabBar.preferredSize.height;
 

--- a/lib/presentation/pages/youtube/detail/youtube_contents_detail_state.dart
+++ b/lib/presentation/pages/youtube/detail/youtube_contents_detail_state.dart
@@ -1,10 +1,12 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/features/chat/repositories/entities/youtube_qna_entity.dart';
+import 'package:techtalk/features/contents/repositories/entities/summary_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_contents_detail_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_video_data_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
 import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_contents_detail_provider.dart';
 import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_contents_detail_qnas_provider.dart';
+import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_summary_provider.dart';
 import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_video_data_provider.dart';
 
 mixin class YoutubeContentsDetailState {
@@ -28,4 +30,12 @@ mixin class YoutubeContentsDetailState {
   AsyncValue<List<YoutubeQnaEntity>> youtubeContentsDetailQnasAsync(
           WidgetRef ref, String contentsId) =>
       ref.watch(youtubeContentsDetailQnasProvider(contentsId));
+
+  ///
+  ///
+  ///
+  AsyncValue<SummaryEntity> summaryAsync(WidgetRef ref,
+      {required String contentId}) {
+    return ref.watch(youtubeSummaryProvider(contentId));
+  }
 }

--- a/lib/presentation/pages/youtube/detail/youtube_contents_detail_state.dart
+++ b/lib/presentation/pages/youtube/detail/youtube_contents_detail_state.dart
@@ -1,9 +1,11 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:techtalk/features/chat/repositories/entities/youtube_qna_entity.dart';
+import 'package:techtalk/features/contents/data_source/remote/youtube_contents_detail_ref.dart';
 import 'package:techtalk/features/contents/repositories/entities/summary_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_contents_detail_entity.dart';
 import 'package:techtalk/features/contents/repositories/entities/youtube_video_data_entity.dart';
 import 'package:techtalk/features/topic/topic.dart';
+import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_content_qna_provider.dart';
 import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_contents_detail_provider.dart';
 import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_contents_detail_qnas_provider.dart';
 import 'package:techtalk/presentation/pages/youtube/detail/providers/youtube_summary_provider.dart';
@@ -27,15 +29,25 @@ mixin class YoutubeContentsDetailState {
   ///
   /// 테크톡 DB에서 불러오는 해당 비디오 컨텐츠 데이터
   ///
+  @Deprecated('구조 변경으로 사용안함')
   AsyncValue<List<YoutubeQnaEntity>> youtubeContentsDetailQnasAsync(
           WidgetRef ref, String contentsId) =>
       ref.watch(youtubeContentsDetailQnasProvider(contentsId));
 
   ///
-  ///
+  /// 콘텐츠 요약 정보
   ///
   AsyncValue<SummaryEntity> summaryAsync(WidgetRef ref,
       {required String contentId}) {
     return ref.watch(youtubeSummaryProvider(contentId));
   }
+
+  ///
+  /// 콘텐츠 문답 리스트
+  ///
+  AsyncValue<List<YoutubeQnaEntity>> qnasAsync(
+    WidgetRef ref, {
+    required String contentId,
+  }) =>
+      ref.watch(youtubeContentQnaProvider(contentId));
 }

--- a/lib/presentation/pages/youtube/main/widgets/content_list_view.p.dart
+++ b/lib/presentation/pages/youtube/main/widgets/content_list_view.p.dart
@@ -25,7 +25,13 @@ class _ContentListView extends HookConsumerWidget
                   height: 56,
                   fit: BoxFit.cover,
                 ),
-                title: Text(item.contentsTitle),
+                title: Wrap(
+                  children: [
+                    Text(item.contentsTitle),
+                    ...item.relatedSkillIds.map((e) => Text(e.name)),
+                    Text('질문 개수 : ${item.qnaNum}'),
+                  ],
+                ),
                 subtitle: Text('Author: ${item.channel.name}'),
                 trailing: Text(
                   '${item.videoDuration.inMinutes}m ${item.videoDuration.inSeconds % 60}s',


### PR DESCRIPTION
## 📝 무엇이 문제였나요?

![comapre](https://github.com/user-attachments/assets/34be2f0d-0d30-4ac6-9dcf-7822834b2d91)
기존 영상학습(유튜브) 관련 firestore는 메인 탐색탭에서 호출되는 콘텐츠 데이터를 관리하는 `YoutubeOverview` 컬렉션과 , 각 콘텐츠의 상세 정보를 관리하는 `YoutubeDetail`로 구성되어 있음. 이러한 구조가 아래와 같은 단점이 있을 것으로 판단됨.

### 1. 중복된 데이터 호출
Overview에서 호출한 데이터와 Detail에서 호출하는 데이터가 중복됨. 상세 화면으로 이동할 때 필요한 정보를 argument로 전달해준다면, 굳이 Overview 컬렉션에 중복된 필드 데이터를 적재하지 않아도 됨.
> 딥링크로 상세페이지에 진입하는 경우에는?
메인 탐색탭 -> 상세 페이지를 이동하는 구조에서 Detail 컬렉션에 Overview 컬렉션에 있는 필드값들이 필요 없겠지만,
딥링크 -> 상세 페이지로 이동하는 구조에서 Overview 관련 데이터가 없으니 문제가 발생할 수 있음. 해당 문제점은 상세 페이지에 랜딩했을 시 route argument가 nullable한지 여부를 기준값으로 Oerview 정보를 호출하는 방식을 적용하려고 했음. 물론 아직 딥링크 관련 기능은 존재 하지않음.


### 2. 데이터 수정 변경에 취약
유튜브 콘텐츠 같은 경우에는 썸네일 이미지가 변경되거나, 영상 자체가 삭제되는 경우가 빈번함. 이러한 경우 firestore db에 관련 콘텐츠의 정보를 변경하거나 삭제해주어야하는데, 기존 구조에서는 `YoutubeOverview`, `YoutubeDetail` 컬렉션을 모두 수정,삭제를 해주어야함. 즉 데이터 변경에 쿼리를 2번씩 때려야 하는 구조임.

또한 데이터 필드가 추가되는 경우에도 비슷한 문제점이 있을 수 있음. 메인 탐색탭과 상세페이지에 `좋아요` 수를 보여주는 기능이 추가된다고 했을 경우에도 좋아요 count가 올라갈 때 마다 2개의 컬렉션의 document를 업데이트 해주어야 함.


<br>

## 🔍 어떻게 해결했나요? 
![solution](https://github.com/user-attachments/assets/774a04ca-c16e-4569-ae60-9996cf3315cc)
- 기존 `YoutubeDetail` 컬렉션을 제거하고,`YoutubeOverview`와 중북이 안되는 상세 정보만 `YoutubeOverview`의 서브컬렉션에 적재.
- `YoutubeDetail`의 서브컬렉션에 있던 `Qna` 컬렉션도 해당 구조로 변경.


<br>

## 👥 리뷰어
@Yellowtoast , @yundal8755 

<br>

## 📌 기타 사항
-제안드린 구조에서 언제든지 롤백 가능하니 편하게 의견 주세요~ 


<br>
